### PR TITLE
feat: spaCy + roberta-argument segmenter (Task 5)

### DIFF
--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -1,0 +1,28 @@
+import spacy
+from transformers import pipeline as hf_pipeline
+from functools import lru_cache
+
+_nlp = spacy.load("en_core_web_sm")
+
+@lru_cache(maxsize=1)
+def _arg_classifier():
+    return hf_pipeline(
+        "text-classification",
+        model="chkla/roberta-argument",
+        device=-1,
+    )
+
+def get_argument_spans(text: str) -> list[dict]:
+    if not text.strip():
+        return []
+    doc = _nlp(text)
+    sentences = list(doc.sents)
+    if not sentences:
+        return []
+    texts = [s.text for s in sentences]
+    labels = _arg_classifier()(texts, batch_size=16, truncation=True)
+    return [
+        {"text": sent.text, "start": sent.start_char, "end": sent.end_char}
+        for sent, label in zip(sentences, labels)
+        if label["label"] == "ARGUMENT"   # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT"
+    ]

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -2,7 +2,9 @@ import spacy
 from transformers import pipeline as hf_pipeline
 from functools import lru_cache
 
-_nlp = spacy.load("en_core_web_sm")
+@lru_cache(maxsize=1)
+def _nlp():
+    return spacy.load("en_core_web_sm")
 
 @lru_cache(maxsize=1)
 def _arg_classifier():
@@ -15,7 +17,7 @@ def _arg_classifier():
 def get_argument_spans(text: str) -> list[dict]:
     if not text.strip():
         return []
-    doc = _nlp(text)
+    doc = _nlp()(text)
     sentences = list(doc.sents)
     if not sentences:
         return []

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -3,3 +3,5 @@ asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 asyncio_default_test_loop_scope = function
 testpaths = tests
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/backend/tests/test_segmenter.py
+++ b/backend/tests/test_segmenter.py
@@ -1,0 +1,23 @@
+import pytest
+
+pytestmark = pytest.mark.slow
+
+from pipeline.segmenter import get_argument_spans  # noqa: E402
+
+ARGUMENTATIVE = "Taxes are theft and the government has no right to take your money."
+NON_ARG = "The weather in Paris is often mild in spring."
+
+def test_returns_list():
+    assert isinstance(get_argument_spans(ARGUMENTATIVE), list)
+
+def test_argumentative_sentence_included():
+    spans = get_argument_spans(ARGUMENTATIVE)
+    assert any(ARGUMENTATIVE[:20] in s["text"] for s in spans)
+
+def test_span_has_required_keys():
+    spans = get_argument_spans(ARGUMENTATIVE)
+    assert len(spans) > 0
+    assert {"text", "start", "end"} <= spans[0].keys()
+
+def test_empty_text_returns_empty():
+    assert get_argument_spans("") == []


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    text[Raw text] --> spacy[spaCy en_core_web_sm\nsentence segmentation]
    spacy --> sents[List of sentences]
    sents --> roberta[chkla/roberta-argument\nbatch inference]
    roberta --> filter[label == ARGUMENT]
    filter --> spans[Argument spans\nstart/end char offsets]
```

## Summary

- `backend/pipeline/segmenter.py` — spaCy tokenizes text into sentences; roberta-argument filters to argument spans; returns dicts with `text`, `start`, `end`
- `_arg_classifier()` is `lru_cache(maxsize=1)` — model loads once per process
- Uses actual model label `"ARGUMENT"` (plan spec incorrectly said `"LABEL_1"`)
- `backend/tests/test_segmenter.py` — 4 tests, all `@pytest.mark.slow` (CI skips with `-m "not slow"`)

## Test plan

- [x] `pytest tests/ -v -m "not slow"` — passes (slow tests excluded from CI)
- [x] `ruff check .` — clean

## Plan reference

Task 5 — `backend/pipeline/segmenter.py`