### PR TITLE
feat: FAISS nearest-neighbor classifier (Task 7)

### DIFF
--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -1,0 +1,38 @@
+import json
+import pathlib
+import numpy as np
+from functools import lru_cache
+from sentence_transformers import SentenceTransformer
+import faiss
+
+DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
+CONFIDENCE_THRESHOLD = 0.82
+
+
+@lru_cache(maxsize=1)
+def _load_resources():
+    model = SentenceTransformer("all-mpnet-base-v2")
+    index = faiss.read_index(str(DATA_DIR / "logical_fallacy.index"))
+    labels = json.loads((DATA_DIR / "logical_fallacy_labels.json").read_text())
+    return model, index, labels
+
+
+def classify_spans(spans: list[dict]) -> list[dict]:
+    if not spans:
+        return []
+    model, index, labels = _load_resources()
+    embeddings = model.encode(
+        [s["text"] for s in spans], batch_size=32, normalize_embeddings=True
+    )
+    embeddings = np.array(embeddings, dtype="float32")
+    distances, indices = index.search(embeddings, k=1)
+    result = []
+    for span, dist, idx in zip(spans, distances, indices):
+        confidence = float(dist[0])
+        result.append({
+            **span,
+            "fallacy_type": labels[int(idx[0])],
+            "confidence": confidence,
+            "status": "confirmed" if confidence >= CONFIDENCE_THRESHOLD else "possibly",
+        })
+    return result

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,0 +1,20 @@
+import pytest
+from pipeline.classifier import classify_spans
+
+pytestmark = pytest.mark.slow
+
+
+def test_returns_status_and_fallacy_type():
+    spans = [{"text": "Everyone knows vaccines cause autism.", "start": 0, "end": 36}]
+    result = classify_spans(spans)
+    assert len(result) == 1
+    assert result[0]["status"] in ("confirmed", "possibly")
+    assert "fallacy_type" in result[0]
+    assert "confidence" in result[0]
+
+
+def test_preserves_original_keys():
+    spans = [{"text": "All politicians lie.", "start": 0, "end": 20}]
+    result = classify_spans(spans)
+    assert result[0]["start"] == 0
+    assert result[0]["end"] == 20

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,9 +1,8 @@
 import pytest
 from pipeline.classifier import classify_spans
 
-pytestmark = pytest.mark.slow
 
-
+@pytest.mark.slow
 def test_returns_status_and_fallacy_type():
     spans = [{"text": "Everyone knows vaccines cause autism.", "start": 0, "end": 36}]
     result = classify_spans(spans)
@@ -13,8 +12,37 @@ def test_returns_status_and_fallacy_type():
     assert "confidence" in result[0]
 
 
+@pytest.mark.slow
 def test_preserves_original_keys():
     spans = [{"text": "All politicians lie.", "start": 0, "end": 20}]
     result = classify_spans(spans)
     assert result[0]["start"] == 0
     assert result[0]["end"] == 20
+
+
+def test_threshold_determines_status(monkeypatch):
+    import numpy as np
+    import types
+
+    fake_model = types.SimpleNamespace(
+        encode=lambda texts, **kw: np.array([[1.0] * 768], dtype="float32")
+    )
+    fake_index = types.SimpleNamespace(
+        search=lambda emb, k: (np.array([[0.85]], dtype="float32"), np.array([[0]]))
+    )
+    fake_labels = ["ad populum"]
+
+    from pipeline import classifier
+    monkeypatch.setattr(classifier, "_load_resources", lambda: (fake_model, fake_index, fake_labels))
+
+    result = classifier.classify_spans([{"text": "x", "start": 0, "end": 1}])
+    assert result[0]["status"] == "confirmed"
+    assert result[0]["fallacy_type"] == "ad populum"
+
+    # Below threshold
+    fake_index2 = types.SimpleNamespace(
+        search=lambda emb, k: (np.array([[0.75]], dtype="float32"), np.array([[0]]))
+    )
+    monkeypatch.setattr(classifier, "_load_resources", lambda: (fake_model, fake_index2, fake_labels))
+    result2 = classifier.classify_spans([{"text": "x", "start": 0, "end": 1}])
+    assert result2[0]["status"] == "possibly"


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    spans[list of argument spans\ntext + start + end] --> encode[SentenceTransformer\nall-mpnet-base-v2\nnormalize_embeddings=True]
    encode --> search[FAISS IndexFlatIP\nk=1 nearest neighbor]
    search --> threshold{confidence\n≥ 0.82?}
    threshold -- yes --> confirmed[status: confirmed]
    threshold -- no --> possibly[status: possibly]
    confirmed & possibly --> out[spans + fallacy_type\n+ confidence + status]
```

## Summary

- `backend/pipeline/classifier.py` — lazy-loads model/index/labels via `@lru_cache`; encodes spans, searches FAISS index, annotates each span with `fallacy_type`, `confidence`, and `status`
- `sentence_transformers` imported before `faiss` (segfault prevention)
- `CONFIDENCE_THRESHOLD = 0.82`: ≥ → `"confirmed"`, below → `"possibly"`
- `backend/tests/test_classifier.py` — 2 slow-marked tests; both pass

## Test plan

- [x] `pytest tests/test_classifier.py -v` — 2 passed
- [x] `pytest tests/ -v -m "not slow"` — 10 passed, no regressions
- [x] `ruff check .` — clean

## Plan reference

Task 7 — `backend/pipeline/classifier.py`