### PR TITLE
feat: GPT-4o mini explainer with Structured Outputs (Task 8)

### DIFF
--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 from openai import OpenAI
 from models.span import (ExplainerOutput, ExplainerSpan, ExplainerChallenge,
                           ExplainerQuestion)
 from pipeline.challenge_types import challenge_type_for
+
+logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = """You are a fallacy explanation engine. For each span you receive a text excerpt
 and an assigned fallacy_type. Generate:
@@ -62,13 +65,16 @@ def generate_content(
     client: OpenAI | None = None,
 ) -> ExplainerOutput:
     if client is None:
-        client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if api_key is None:
+            return _fallback_content(spans)
+        client = OpenAI(api_key=api_key)
 
     payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
 
     for attempt in range(2):
         try:
-            response = client.beta.chat.completions.parse(
+            response = client.chat.completions.parse(
                 model="gpt-4o-mini",
                 messages=[
                     {"role": "system", "content": _SYSTEM_PROMPT},
@@ -80,7 +86,8 @@ def generate_content(
             if msg.refusal:
                 raise ValueError(f"Model refused: {msg.refusal}")
             return msg.parsed
-        except Exception:
+        except Exception as e:
+            logger.warning("explainer attempt %d failed: %s", attempt, e, exc_info=True)
             if attempt == 1:
                 return _fallback_content(spans)
     return _fallback_content(spans)

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -1,0 +1,86 @@
+import json
+import os
+from openai import OpenAI
+from models.span import (ExplainerOutput, ExplainerSpan, ExplainerChallenge,
+                          ExplainerQuestion)
+from pipeline.challenge_types import challenge_type_for
+
+_SYSTEM_PROMPT = """You are a fallacy explanation engine. For each span you receive a text excerpt
+and an assigned fallacy_type. Generate:
+- explanation: what the fallacy is and why this specific span was flagged (2-3 sentences)
+- challenge: targeted question to help the user decide if it's really a fallacy
+  - type: one of counterexample|domain_check|meaning_check|representation_check|non_sequitur|premise_check
+  - question.text, question.yes_label, question.no_label
+  - For counterexample: yes_label confirms the fallacy (counterexample exists → fallacy confirmed)
+- if_legitimate: one sentence — what this looks like if the argument is valid
+- if_fallacy: one sentence — what this looks like if it is a fallacy
+
+Also return dependency_rules if any span's challenge only makes sense after another's resolution.
+Never reclassify the assigned fallacy_type."""
+
+_TEMPLATE_QUESTIONS = {
+    "counterexample":       ("Can you name a single instance that disproves this universal claim?",
+                             "Counterexample exists → fallacy confirmed",
+                             "No counterexample → not confirmed"),
+    "domain_check":         ("Does this authority's expertise cover this specific claim?",
+                             "Outside their domain → fallacy",
+                             "Expertise is relevant → not a fallacy"),
+    "meaning_check":        ("Is the key term used with the same meaning throughout?",
+                             "Meaning shifts → fallacy",
+                             "Consistent meaning → not a fallacy"),
+    "representation_check": ("Is this a fair characterization of the original position?",
+                             "Misrepresents it → fallacy",
+                             "Fair representation → not a fallacy"),
+    "non_sequitur":         ("Does this conclusion actually follow from the premise?",
+                             "Doesn't follow → fallacy",
+                             "Follows logically → not a fallacy"),
+    "premise_check":        ("Is this premise established, or simply asserted?",
+                             "Not established → fallacy",
+                             "Well established → not a fallacy"),
+}
+
+def _fallback_content(spans: list[dict]) -> ExplainerOutput:
+    result_spans = []
+    for span in spans:
+        ct = challenge_type_for(span["fallacy_type"])
+        q_text, yes_lbl, no_lbl = _TEMPLATE_QUESTIONS[ct]
+        result_spans.append(ExplainerSpan(
+            id=span["id"],
+            explanation=f"Possibly a {span['fallacy_type']}.",
+            challenge=ExplainerChallenge(
+                type=ct,
+                question=ExplainerQuestion(text=q_text, yes_label=yes_lbl, no_label=no_lbl),
+            ),
+            if_legitimate=None,
+            if_fallacy=None,
+        ))
+    return ExplainerOutput(spans=result_spans, dependency_rules=[])
+
+def generate_content(
+    spans: list[dict],
+    full_text: str,
+    client: OpenAI | None = None,
+) -> ExplainerOutput:
+    if client is None:
+        client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+    payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
+
+    for attempt in range(2):
+        try:
+            response = client.beta.chat.completions.parse(
+                model="gpt-4o-mini",
+                messages=[
+                    {"role": "system", "content": _SYSTEM_PROMPT},
+                    {"role": "user", "content": payload},
+                ],
+                response_format=ExplainerOutput,
+            )
+            msg = response.choices[0].message
+            if msg.refusal:
+                raise ValueError(f"Model refused: {msg.refusal}")
+            return msg.parsed
+        except Exception:
+            if attempt == 1:
+                return _fallback_content(spans)
+    return _fallback_content(spans)

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -29,7 +29,7 @@ def _mock_parsed():
 
 def test_returns_enriched_output():
     mock_client = MagicMock()
-    mock_client.beta.chat.completions.parse.return_value = MagicMock(
+    mock_client.chat.completions.parse.return_value = MagicMock(
         choices=[MagicMock(message=MagicMock(parsed=_mock_parsed(), refusal=None))]
     )
     result = generate_content(SPANS, "Everyone knows politicians lie.", client=mock_client)
@@ -44,10 +44,16 @@ def test_fallback_returns_template_content():
 
 def test_retries_on_failure():
     mock_client = MagicMock()
-    mock_client.beta.chat.completions.parse.side_effect = [
+    mock_client.chat.completions.parse.side_effect = [
         Exception("timeout"),
         MagicMock(choices=[MagicMock(message=MagicMock(parsed=_mock_parsed(), refusal=None))])
     ]
     result = generate_content(SPANS, "text", client=mock_client)
     assert result.spans[0].explanation == "Invokes consensus without evidence."
-    assert mock_client.beta.chat.completions.parse.call_count == 2
+    assert mock_client.chat.completions.parse.call_count == 2
+
+def test_fallback_when_no_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    result = generate_content(SPANS, "text")
+    assert result.spans[0].id == "a"
+    assert result.spans[0].explanation != ""

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+from pipeline.explainer import generate_content, _fallback_content
+
+SPANS = [{
+    "id": "a", "text": "Everyone knows politicians lie",
+    "start": 0, "end": 30, "status": "possibly",
+    "fallacy_type": "Ad Populum", "confidence": 0.71,
+}]
+
+def _mock_parsed():
+    from models.span import (ExplainerOutput, ExplainerSpan, ExplainerChallenge,
+                              ExplainerQuestion)
+    return ExplainerOutput(
+        spans=[ExplainerSpan(
+            id="a", explanation="Invokes consensus without evidence.",
+            challenge=ExplainerChallenge(
+                type="premise_check",
+                question=ExplainerQuestion(
+                    text="Is this consensus established?",
+                    yes_label="Not established → fallacy",
+                    no_label="Consensus is real → not a fallacy",
+                ),
+            ),
+            if_legitimate="Survey data shows 80% of voters...",
+            if_fallacy="No evidence offered.",
+        )],
+        dependency_rules=[],
+    )
+
+def test_returns_enriched_output():
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(parsed=_mock_parsed(), refusal=None))]
+    )
+    result = generate_content(SPANS, "Everyone knows politicians lie.", client=mock_client)
+    assert result.spans[0].explanation == "Invokes consensus without evidence."
+    assert result.dependency_rules == []
+
+def test_fallback_returns_template_content():
+    result = _fallback_content(SPANS)
+    assert result.spans[0].id == "a"
+    assert result.spans[0].explanation != ""
+    assert result.dependency_rules == []
+
+def test_retries_on_failure():
+    mock_client = MagicMock()
+    mock_client.beta.chat.completions.parse.side_effect = [
+        Exception("timeout"),
+        MagicMock(choices=[MagicMock(message=MagicMock(parsed=_mock_parsed(), refusal=None))])
+    ]
+    result = generate_content(SPANS, "text", client=mock_client)
+    assert result.spans[0].explanation == "Invokes consensus without evidence."
+    assert mock_client.beta.chat.completions.parse.call_count == 2


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    spans[classified spans\n+ full_text] --> parse[client.beta.chat.completions.parse\ngpt-4o-mini\nresponse_format=ExplainerOutput]
    parse -- success --> out[ExplainerOutput\nexplanation + challenge\n+ if_legitimate + if_fallacy]
    parse -- exception attempt 1 --> retry[retry]
    retry -- success --> out
    retry -- exception attempt 2 --> fallback[_fallback_content\ntemplate explanations]
    parse -- refusal --> fallback
    fallback --> out
```

## Summary

- `backend/pipeline/explainer.py` — `generate_content` calls `beta.chat.completions.parse()` with `response_format=ExplainerOutput` (Structured Outputs); retries once on any exception; falls back to template content on second failure or refusal
- `_fallback_content` uses `challenge_type_for` to pick template question per fallacy type
- `backend/tests/test_explainer.py` — 3 tests: happy path (mocked), fallback, retry logic

## Test plan

- [x] `pytest tests/test_explainer.py -v` — 3 passed
- [x] `pytest tests/ -v -m "not slow"` — 14 passed, no regressions
- [x] `ruff check .` — clean

## Plan reference

Task 8 — `backend/pipeline/explainer.py`