### PR TITLE
feat: FastAPI /analyze endpoint (Task 9)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,7 @@ async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
         sid = span["id"]
         c = content_by_id.get(sid)
         model_generated = c is not None
-        if not model_generated:
+        if c is None:
             c = _fallback_content([span]).spans[0]
         ch = c.challenge
         spans_out.append(SpanResult(

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,7 @@ async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
         meta=AnalysisMeta(
             sentence_count=len(list(_nlp()(text).sents)),
             argument_span_count=len(raw_spans),
-            fallacy_count=len(spans_out),
+            fallacy_count=sum(1 for s in spans_out if s.status == "confirmed"),
             processing_ms=ms,
         ),
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,19 +1,13 @@
 import time
-from functools import lru_cache
-import spacy
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from models.span import (
     AnalyzeRequest, AnalyzeResponse, SpanResult,
     Challenge, Question, ChallengeType, DependencyRule, AnalysisMeta,
 )
-from pipeline.segmenter import get_argument_spans
+from pipeline.segmenter import get_argument_spans, _nlp
 from pipeline.classifier import classify_spans
-from pipeline.explainer import generate_content
-
-@lru_cache(maxsize=1)
-def _nlp():
-    return spacy.load("en_core_web_sm")
+from pipeline.explainer import generate_content, _fallback_content
 
 app = FastAPI()
 app.add_middleware(
@@ -43,7 +37,10 @@ async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
     for span in classified:
         sid = span["id"]
         c = content_by_id.get(sid)
-        ch = c.challenge if c else None
+        model_generated = c is not None
+        if not model_generated:
+            c = _fallback_content([span]).spans[0]
+        ch = c.challenge
         spans_out.append(SpanResult(
             id=sid,
             text=span["text"],
@@ -51,18 +48,18 @@ async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
             end=span["end"],
             status=span["status"],
             fallacy_type=span["fallacy_type"],
-            explanation=c.explanation if c else "",
+            explanation=c.explanation,
             challenge=Challenge(
-                type=ChallengeType(ch.type if ch else "non_sequitur"),
+                type=ChallengeType(ch.type),
                 question=Question(
-                    text=ch.question.text if ch else "",
-                    yes_label=ch.question.yes_label if ch else "Yes",
-                    no_label=ch.question.no_label if ch else "No",
+                    text=ch.question.text,
+                    yes_label=ch.question.yes_label,
+                    no_label=ch.question.no_label,
                 ),
             ),
-            if_legitimate=c.if_legitimate if c else None,
-            if_fallacy=c.if_fallacy if c else None,
-            content_generated=c is not None,
+            if_legitimate=c.if_legitimate,
+            if_fallacy=c.if_fallacy,
+            content_generated=model_generated,
         ))
 
     rules_out = [

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,86 @@
+import time
+from functools import lru_cache
+import spacy
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from models.span import (
+    AnalyzeRequest, AnalyzeResponse, SpanResult,
+    Challenge, Question, ChallengeType, DependencyRule, AnalysisMeta,
+)
+from pipeline.segmenter import get_argument_spans
+from pipeline.classifier import classify_spans
+from pipeline.explainer import generate_content
+
+@lru_cache(maxsize=1)
+def _nlp():
+    return spacy.load("en_core_web_sm")
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_methods=["POST"],
+    allow_headers=["*"],
+)
+
+@app.post("/analyze", response_model=AnalyzeResponse)
+async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
+    if not req.text.strip():
+        raise HTTPException(status_code=422, detail="text must not be empty")
+
+    t0 = time.monotonic()
+    text = req.text[: req.max_chars]
+
+    raw_spans = get_argument_spans(text)
+    classified = classify_spans(raw_spans)
+    for i, span in enumerate(classified):
+        span["id"] = f"span_{i}"
+
+    explainer_out = generate_content(classified, text)
+    content_by_id = {s.id: s for s in explainer_out.spans}
+
+    spans_out: list[SpanResult] = []
+    for span in classified:
+        sid = span["id"]
+        c = content_by_id.get(sid)
+        ch = c.challenge if c else None
+        spans_out.append(SpanResult(
+            id=sid,
+            text=span["text"],
+            start=span["start"],
+            end=span["end"],
+            status=span["status"],
+            fallacy_type=span["fallacy_type"],
+            explanation=c.explanation if c else "",
+            challenge=Challenge(
+                type=ChallengeType(ch.type if ch else "non_sequitur"),
+                question=Question(
+                    text=ch.question.text if ch else "",
+                    yes_label=ch.question.yes_label if ch else "Yes",
+                    no_label=ch.question.no_label if ch else "No",
+                ),
+            ),
+            if_legitimate=c.if_legitimate if c else None,
+            if_fallacy=c.if_fallacy if c else None,
+            content_generated=c is not None,
+        ))
+
+    rules_out = [
+        DependencyRule(
+            source_id=r.source_id, dependent_id=r.dependent_id,
+            when=r.when, effect=r.effect, reason=r.reason,
+        )
+        for r in explainer_out.dependency_rules
+    ]
+
+    ms = int((time.monotonic() - t0) * 1000)
+    return AnalyzeResponse(
+        spans=spans_out,
+        rules=rules_out,
+        meta=AnalysisMeta(
+            sentence_count=len(list(_nlp()(text).sents)),
+            argument_span_count=len(raw_spans),
+            fallacy_count=len(spans_out),
+            processing_ms=ms,
+        ),
+    )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+from httpx import AsyncClient, ASGITransport
+from models.span import ExplainerOutput, ExplainerSpan, ExplainerChallenge, ExplainerQuestion
+
+def _mock_explainer_output():
+    return ExplainerOutput(
+        spans=[ExplainerSpan(
+            id="span_0",
+            explanation="Universal claim.",
+            challenge=ExplainerChallenge(
+                type="counterexample",
+                question=ExplainerQuestion(
+                    text="Name a counterexample?",
+                    yes_label="Exists → fallacy", no_label="None → not a fallacy"),
+            ),
+            if_legitimate="Backed by data.", if_fallacy="No evidence.",
+        )],
+        dependency_rules=[],
+    )
+
+MOCK_SEGMENTS = [{"text": "All scientists lie.", "start": 0, "end": 18}]
+MOCK_CLASSIFIED = [{"text": "All scientists lie.", "start": 0, "end": 18,
+                    "fallacy_type": "Faulty Generalization", "confidence": 0.91,
+                    "status": "confirmed"}]
+
+async def test_analyze_returns_spans():
+    from main import app
+    with (patch("main.get_argument_spans", return_value=MOCK_SEGMENTS),
+          patch("main.classify_spans", return_value=MOCK_CLASSIFIED),
+          patch("main.generate_content", return_value=_mock_explainer_output())):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/analyze", json={"text": "All scientists lie."})
+    assert resp.status_code == 200
+    assert resp.json()["spans"][0]["fallacy_type"] == "Faulty Generalization"
+
+async def test_analyze_empty_text_returns_422():
+    from main import app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post("/analyze", json={"text": ""})
+    assert resp.status_code == 422
+
+async def test_analyze_no_spans_returns_empty():
+    from main import app
+    empty = ExplainerOutput(spans=[], dependency_rules=[])
+    with (patch("main.get_argument_spans", return_value=[]),
+          patch("main.classify_spans", return_value=[]),
+          patch("main.generate_content", return_value=empty)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/analyze", json={"text": "The sky is blue."})
+    assert resp.status_code == 200
+    assert resp.json()["spans"] == []

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import pytest
 from httpx import AsyncClient, ASGITransport
 from models.span import ExplainerOutput, ExplainerSpan, ExplainerChallenge, ExplainerQuestion
 
@@ -23,6 +24,7 @@ MOCK_CLASSIFIED = [{"text": "All scientists lie.", "start": 0, "end": 18,
                     "fallacy_type": "Faulty Generalization", "confidence": 0.91,
                     "status": "confirmed"}]
 
+@pytest.mark.asyncio
 async def test_analyze_returns_spans():
     from main import app
     with (patch("main.get_argument_spans", return_value=MOCK_SEGMENTS),
@@ -33,12 +35,14 @@ async def test_analyze_returns_spans():
     assert resp.status_code == 200
     assert resp.json()["spans"][0]["fallacy_type"] == "Faulty Generalization"
 
+@pytest.mark.asyncio
 async def test_analyze_empty_text_returns_422():
     from main import app
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         resp = await c.post("/analyze", json={"text": ""})
     assert resp.status_code == 422
 
+@pytest.mark.asyncio
 async def test_analyze_no_spans_returns_empty():
     from main import app
     empty = ExplainerOutput(spans=[], dependency_rules=[])


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    req[POST /analyze\nAnalyzeRequest] --> strip[strip to max_chars]
    strip --> seg[get_argument_spans\nspaCy + roberta]
    seg --> cls[classify_spans\nFAISS]
    cls --> ids[assign span IDs]
    ids --> exp[generate_content\nGPT-4o mini]
    exp --> assemble[assemble SpanResult list]
    assemble --> resp[AnalyzeResponse\nspans + rules + meta]
```

## Summary

- `backend/main.py` — FastAPI app with CORS (localhost:5173), `POST /analyze` wires the full pipeline; spaCy lazy-loaded via `@lru_cache`; `fallacy_count` counts only `status=="confirmed"` spans
- `backend/tests/test_api.py` — 3 async tests with explicit `@pytest.mark.asyncio` decorators

## Test plan

- [x] `pytest tests/test_api.py -v` — 3 passed
- [x] `pytest tests/ -v -m "not slow"` — 18 passed, no regressions
- [x] `ruff check .` — clean

## Plan reference

Task 9 — `backend/main.py`