### PR TITLE
feat: TypeScript types + fetch wrapper (Task 10)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,11 @@
+import type { AnalyzeResponse } from './types'
+
+export async function analyze(text: string): Promise<AnalyzeResponse> {
+  const resp = await fetch('/analyze', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+  if (!resp.ok) throw new Error(String(resp.status))
+  return resp.json()
+}

--- a/frontend/src/test/api.test.ts
+++ b/frontend/src/test/api.test.ts
@@ -1,0 +1,20 @@
+import { it, expect, vi, beforeEach } from 'vitest'
+import { analyze } from '../api'
+
+beforeEach(() => { vi.restoreAllMocks() })
+
+it('returns data on success', async () => {
+  const mockData = { spans: [], rules: [], meta: { sentence_count: 1, argument_span_count: 0, fallacy_count: 0, processing_ms: 10 } }
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response(JSON.stringify(mockData), { status: 200 })
+  )
+  const result = await analyze('some text')
+  expect(result.spans).toEqual([])
+})
+
+it('throws on non-200', async () => {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+    new Response('{"detail":"error"}', { status: 422 })
+  )
+  await expect(analyze('bad')).rejects.toThrow('422')
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,27 @@
+export type ChallengeType =
+  | 'counterexample' | 'domain_check' | 'meaning_check'
+  | 'representation_check' | 'non_sequitur' | 'premise_check'
+
+export interface Question { text: string; yes_label: string; no_label: string }
+export interface Challenge { type: ChallengeType; question: Question }
+
+export interface DependencyRule {
+  source_id: string; dependent_id: string
+  when: 'CONFIRMED' | 'CLEARED'; effect: 'moot' | 'activate'; reason: string
+}
+
+export interface SpanResult {
+  id: string; text: string; start: number; end: number
+  status: 'confirmed' | 'possibly'; fallacy_type: string; explanation: string
+  challenge: Challenge; if_legitimate: string | null; if_fallacy: string | null
+  content_generated: boolean
+}
+
+export interface AnalysisMeta {
+  sentence_count: number; argument_span_count: number
+  fallacy_count: number; processing_ms: number
+}
+
+export interface AnalyzeResponse { spans: SpanResult[]; rules: DependencyRule[]; meta: AnalysisMeta }
+
+export type Resolution = 'PENDING' | 'CONFIRMED' | 'CLEARED' | 'MOOT' | 'DORMANT'


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    api[api.ts\nanalyze] -- POST /analyze --> backend[FastAPI\n/analyze]
    backend -- AnalyzeResponse --> api
    api -- throws Error(status) --> caller[caller]
    types[types.ts] -- SpanResult\nDependencyRule\nAnalyzeResponse\nResolution... --> api
    types --> hooks[future hooks]
    types --> components[future components]
```

## Summary

- `frontend/src/types.ts` — all 8 domain types matching the backend Pydantic models
- `frontend/src/api.ts` — `analyze()` fetch wrapper, throws on non-200
- `frontend/src/test/api.test.ts` — 2 tests: success path and 422 error

## Test plan

- [x] `npm test` — 2 passed
- [x] `npx tsc --noEmit` — clean

## Plan reference

Task 10 — `frontend/src/types.ts`, `frontend/src/api.ts`