### PR TITLE
feat: splitBySpans + fallacyColors utilities (Task 12)

### DIFF
--- a/frontend/src/test/splitBySpans.test.ts
+++ b/frontend/src/test/splitBySpans.test.ts
@@ -1,0 +1,33 @@
+import { splitBySpans } from '../utils/splitBySpans'
+import type { SpanResult } from '../types'
+
+const makeSpan = (id: string, start: number, end: number): SpanResult => ({
+  id, text: 'x', start, end, status: 'confirmed', fallacy_type: 'Ad Populum',
+  explanation: '', content_generated: true,
+  challenge: { type: 'premise_check', question: { text: '', yes_label: '', no_label: '' } },
+  if_legitimate: null, if_fallacy: null,
+})
+
+it('splits into plain and span segments', () => {
+  const segs = splitBySpans('Hello world, goodbye world.', [makeSpan('a', 6, 11)])
+  expect(segs).toHaveLength(3)
+  expect(segs[0]).toEqual({ type: 'plain', text: 'Hello ' })
+  expect(segs[1].type).toBe('span')
+  expect(segs[2]).toEqual({ type: 'plain', text: ', goodbye world.' })
+})
+
+it('handles span at start', () => {
+  const segs = splitBySpans('Bad claim here.', [makeSpan('a', 0, 9)])
+  expect(segs[0].type).toBe('span')
+})
+
+it('handles no spans', () => {
+  const segs = splitBySpans('plain text', [])
+  expect(segs).toHaveLength(1)
+  expect(segs[0]).toEqual({ type: 'plain', text: 'plain text' })
+})
+
+it('handles adjacent spans', () => {
+  const segs = splitBySpans('AABB', [makeSpan('a', 0, 2), makeSpan('b', 2, 4)])
+  expect(segs.every(s => s.type === 'span')).toBe(true)
+})

--- a/frontend/src/utils/fallacyColors.ts
+++ b/frontend/src/utils/fallacyColors.ts
@@ -1,0 +1,18 @@
+const BG: Record<string, string> = {
+  'Ad Populum':            'rgba(239,68,68,0.25)',
+  'Fallacy of Logic':      'rgba(167,139,250,0.25)',
+  'Faulty Generalization': 'rgba(251,191,36,0.25)',
+  'Fallacy of Extension':  'rgba(52,211,153,0.25)',
+  'Equivocation':          'rgba(99,102,241,0.25)',
+  'Fallacy of Credibility':'rgba(249,115,22,0.25)',
+}
+const BORDER: Record<string, string> = {
+  'Ad Populum':            '#ef4444',
+  'Fallacy of Logic':      '#a78bfa',
+  'Faulty Generalization': '#fbbf24',
+  'Fallacy of Extension':  '#34d399',
+  'Equivocation':          '#6366f1',
+  'Fallacy of Credibility':'#f97316',
+}
+export const fallacyBg = (t: string) => BG[t] ?? 'rgba(148,163,184,0.2)'
+export const fallacyBorder = (t: string) => BORDER[t] ?? '#94a3b8'

--- a/frontend/src/utils/splitBySpans.ts
+++ b/frontend/src/utils/splitBySpans.ts
@@ -1,0 +1,18 @@
+import type { SpanResult } from '../types'
+
+export type Segment =
+  | { type: 'plain'; text: string }
+  | { type: 'span'; text: string; span: SpanResult }
+
+export function splitBySpans(text: string, spans: SpanResult[]): Segment[] {
+  const sorted = [...spans].sort((a, b) => a.start - b.start)
+  const segments: Segment[] = []
+  let cursor = 0
+  for (const span of sorted) {
+    if (span.start > cursor) segments.push({ type: 'plain', text: text.slice(cursor, span.start) })
+    segments.push({ type: 'span', text: text.slice(span.start, span.end), span })
+    cursor = span.end
+  }
+  if (cursor < text.length) segments.push({ type: 'plain', text: text.slice(cursor) })
+  return segments
+}


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    text[raw text\nstring] --> split[splitBySpans]
    spans[SpanResult[]] --> split
    split --> segs["Segment[]\nplain | span"]
    fallacy_type[fallacy_type\nstring] --> bg[fallacyBg] --> rgba[rgba color]
    fallacy_type --> border[fallacyBorder] --> hex[hex color]
```

## Summary

- `frontend/src/utils/splitBySpans.ts` — splits text into plain/span segments preserving character offsets; handles span-at-start and adjacent spans
- `frontend/src/utils/fallacyColors.ts` — maps fallacy type strings to bg rgba and border hex colors with grey defaults
- `frontend/src/test/splitBySpans.test.ts` — 4 tests covering the split cases

## Test plan

- [x] `npm test` — 13 passed (4 new + 9 existing)
- [x] `npx tsc --noEmit` — clean

## Plan reference

Task 12 — `frontend/src/utils/`