### PR TITLE
fix: resolved card states + dim CLEARED highlights

### DIFF
--- a/frontend/src/components/FindingsList.tsx
+++ b/frontend/src/components/FindingsList.tsx
@@ -3,6 +3,7 @@ import type { SpanResult, DependencyRule, Resolution } from '../types'
 import { ConfirmedCard } from './ConfirmedCard'
 import { PossiblyCard } from './PossiblyCard'
 import { MootCard } from './MootCard'
+import { ResolvedCard } from './ResolvedCard'
 interface Props {
   spans: SpanResult[]
   rules: DependencyRule[]
@@ -18,6 +19,9 @@ export function FindingsList({ spans, rules, resolve, statusOf }: Props) {
         if (status === 'MOOT' && !reviewed.has(span.id)) {
           const rule = rules.find(r => r.dependent_id === span.id && r.effect === 'moot')
           return <MootCard key={span.id} span={span} reason={rule?.reason ?? 'resolved by cascade'} onReviewAnyway={id => setReviewed(prev => new Set(prev).add(id))} />
+        }
+        if (status === 'CONFIRMED' || status === 'CLEARED') {
+          return <ResolvedCard key={span.id} span={span} outcome={status} />
         }
         return span.status === 'confirmed'
           ? <ConfirmedCard key={span.id} span={span} onResolve={resolve} />

--- a/frontend/src/components/Highlight.tsx
+++ b/frontend/src/components/Highlight.tsx
@@ -2,7 +2,7 @@ import type { SpanResult, Resolution } from '../types'
 import { fallacyBg, fallacyBorder } from '../utils/fallacyColors'
 interface Props { span: SpanResult; text: string; resolution: Resolution; onClick: () => void }
 export function Highlight({ span, text, resolution, onClick }: Props) {
-  const isMoot = resolution === 'MOOT'
+  const isMoot = resolution === 'MOOT' || resolution === 'CLEARED'
   return (
     <mark onClick={onClick} role="button" tabIndex={0} onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onClick()} style={{
       background: isMoot ? 'rgba(255,255,255,0.05)' : fallacyBg(span.fallacy_type),

--- a/frontend/src/components/ResolvedCard.tsx
+++ b/frontend/src/components/ResolvedCard.tsx
@@ -1,0 +1,24 @@
+import type { SpanResult, Resolution } from '../types'
+interface Props { span: SpanResult; outcome: Resolution }
+export function ResolvedCard({ span, outcome }: Props) {
+  const isConfirmed = outcome === 'CONFIRMED'
+  return (
+    <div id={`card-${span.id}`} style={{
+      background: isConfirmed ? 'rgba(239,68,68,0.08)' : 'rgba(74,222,128,0.06)',
+      border: `1px solid ${isConfirmed ? 'rgba(239,68,68,0.3)' : 'rgba(74,222,128,0.25)'}`,
+      borderRadius: 8, padding: 14, marginBottom: 12, opacity: 0.75,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+        <span style={{
+          display: 'inline-block', padding: '2px 8px', borderRadius: 4, fontSize: '0.85em',
+          background: isConfirmed ? 'rgba(239,68,68,0.2)' : 'rgba(74,222,128,0.15)',
+          color: isConfirmed ? '#fca5a5' : '#86efac',
+          border: `1px solid ${isConfirmed ? 'rgba(239,68,68,0.3)' : 'rgba(74,222,128,0.3)'}`,
+        }}>
+          {isConfirmed ? `Confirmed — ${span.fallacy_type}` : 'Cleared — not a fallacy'}
+        </span>
+      </div>
+      <div style={{ color: 'inherit', opacity: 0.5, fontStyle: 'italic', fontSize: '0.9em' }}>"{span.text}"</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
  [*] --> PENDING
  PENDING --> CONFIRMED: user clicks yes
  PENDING --> CLEARED: user clicks no
  PENDING --> MOOT: cascade from another span
  CONFIRMED --> [*]: shows ResolvedCard (red)
  CLEARED --> [*]: shows ResolvedCard (green), highlight dims
  MOOT --> [*]: shows MootCard (dimmed)
```

## Summary

- Add `ResolvedCard` component — shows after user resolves a challenge (CONFIRMED = red badge, CLEARED = green badge)
- `FindingsList` now renders `ResolvedCard` for CONFIRMED and CLEARED states instead of keeping challenge buttons visible
- `Highlight` dims CLEARED spans (same treatment as MOOT) so resolved text recedes in annotated view

## Screenshots

N/A — Playwright E2E verification covers this.

## Test plan

- [x] `cd frontend && npm test` — 13 tests green
- [x] `cd frontend && npx tsc --noEmit` — clean

## Plan reference

Bug fix — not in original plan tasks.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)