### PR TITLE
fix: fallacy type display casing + prevent OpenAI timeout hangs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ app.add_middleware(
 )
 
 @app.post("/analyze", response_model=AnalyzeResponse)
-async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
+def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
     if not req.text.strip():
         raise HTTPException(status_code=422, detail="text must not be empty")
 

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -68,7 +68,7 @@ def generate_content(
         api_key = os.environ.get("OPENAI_API_KEY")
         if api_key is None:
             return _fallback_content(spans)
-        client = OpenAI(api_key=api_key)
+        client = OpenAI(api_key=api_key, timeout=30.0)
 
     payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
 

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -72,22 +72,19 @@ def generate_content(
 
     payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
 
-    for attempt in range(2):
-        try:
-            response = client.chat.completions.parse(
-                model="gpt-4o-mini",
-                messages=[
-                    {"role": "system", "content": _SYSTEM_PROMPT},
-                    {"role": "user", "content": payload},
-                ],
-                response_format=ExplainerOutput,
-            )
-            msg = response.choices[0].message
-            if msg.refusal:
-                raise ValueError(f"Model refused: {msg.refusal}")
-            return msg.parsed
-        except Exception as e:
-            logger.warning("explainer attempt %d failed: %s", attempt, e, exc_info=True)
-            if attempt == 1:
-                return _fallback_content(spans)
-    return _fallback_content(spans)
+    try:
+        response = client.chat.completions.parse(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "user", "content": payload},
+            ],
+            response_format=ExplainerOutput,
+        )
+        msg = response.choices[0].message
+        if msg.refusal:
+            raise ValueError(f"Model refused: {msg.refusal}")
+        return msg.parsed
+    except Exception as e:
+        logger.warning("explainer failed: %s", e, exc_info=True)
+        return _fallback_content(spans)

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -68,7 +68,7 @@ def generate_content(
         api_key = os.environ.get("OPENAI_API_KEY")
         if api_key is None:
             return _fallback_content(spans)
-        client = OpenAI(api_key=api_key, timeout=30.0)
+        client = OpenAI(api_key=api_key, timeout=30.0, max_retries=0)
 
     payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
 

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -42,15 +42,13 @@ def test_fallback_returns_template_content():
     assert result.spans[0].explanation != ""
     assert result.dependency_rules == []
 
-def test_retries_on_failure():
+def test_fallback_on_failure():
     mock_client = MagicMock()
-    mock_client.chat.completions.parse.side_effect = [
-        Exception("timeout"),
-        MagicMock(choices=[MagicMock(message=MagicMock(parsed=_mock_parsed(), refusal=None))])
-    ]
+    mock_client.chat.completions.parse.side_effect = Exception("timeout")
     result = generate_content(SPANS, "text", client=mock_client)
-    assert result.spans[0].explanation == "Invokes consensus without evidence."
-    assert mock_client.chat.completions.parse.call_count == 2
+    assert result.spans[0].id == "a"
+    assert result.spans[0].explanation != ""
+    assert mock_client.chat.completions.parse.call_count == 1
 
 def test_fallback_when_no_api_key(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/frontend/src/components/ConfirmedCard.tsx
+++ b/frontend/src/components/ConfirmedCard.tsx
@@ -1,10 +1,11 @@
 import type { SpanResult, Resolution } from '../types'
 import { Challenge } from './Challenge'
+import { formatFallacyType } from '../utils/fallacyColors'
 interface Props { span: SpanResult; onResolve: (id: string, o: Resolution) => void }
 export function ConfirmedCard({ span, onResolve }: Props) {
   return (
     <div id={`card-${span.id}`} style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.35)', borderRadius: 8, padding: 14, marginBottom: 12 }}>
-      <div style={{ fontWeight: 'bold', color: '#fca5a5', marginBottom: 4 }}>Confirmed — {span.fallacy_type}</div>
+      <div style={{ fontWeight: 'bold', color: '#fca5a5', marginBottom: 4 }}>Confirmed — {formatFallacyType(span.fallacy_type)}</div>
       <div style={{ color: '#fca5a5', opacity: 0.75, fontStyle: 'italic', marginBottom: 10 }}>"{span.text}"</div>
       <div style={{ opacity: 0.65, lineHeight: 1.55, marginBottom: 12 }}>{span.explanation}</div>
       <Challenge challenge={span.challenge} onResolve={o => onResolve(span.id, o)} degraded={!span.content_generated} />

--- a/frontend/src/components/MootCard.tsx
+++ b/frontend/src/components/MootCard.tsx
@@ -1,9 +1,10 @@
 import type { SpanResult } from '../types'
+import { formatFallacyType } from '../utils/fallacyColors'
 interface Props { span: SpanResult; reason: string; onReviewAnyway: (id: string) => void }
 export function MootCard({ span, reason, onReviewAnyway }: Props) {
   return (
     <div id={`card-${span.id}`} style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 8, padding: 12, marginBottom: 12, opacity: 0.5 }}>
-      <div style={{ fontSize: '0.8em', marginBottom: 6 }}>MOOT — {span.fallacy_type}</div>
+      <div style={{ fontSize: '0.8em', marginBottom: 6 }}>MOOT — {formatFallacyType(span.fallacy_type)}</div>
       <div style={{ fontStyle: 'italic', marginBottom: 4 }}>"{span.text}"</div>
       <div style={{ fontSize: '0.85em', marginBottom: 10, opacity: 0.7 }}>{reason}</div>
       <button onClick={() => onReviewAnyway(span.id)} style={{ padding: '4px 10px', borderRadius: 4, border: '1px solid rgba(255,255,255,0.15)', background: 'transparent', color: 'inherit', cursor: 'pointer', fontSize: '0.85em' }}>

--- a/frontend/src/components/PossiblyCard.tsx
+++ b/frontend/src/components/PossiblyCard.tsx
@@ -1,11 +1,12 @@
 import type { SpanResult, Resolution } from '../types'
 import { Challenge } from './Challenge'
 import { LegitimacyComparison } from './LegitimacyComparison'
+import { formatFallacyType } from '../utils/fallacyColors'
 interface Props { span: SpanResult; onResolve: (id: string, o: Resolution) => void }
 export function PossiblyCard({ span, onResolve }: Props) {
   return (
     <div id={`card-${span.id}`} style={{ background: 'rgba(251,191,36,0.08)', border: '2px dashed rgba(251,191,36,0.45)', borderRadius: 8, padding: 14, marginBottom: 12 }}>
-      <div style={{ fontWeight: 'bold', color: '#fde68a', marginBottom: 4 }}>⚠ Possibly — {span.fallacy_type}</div>
+      <div style={{ fontWeight: 'bold', color: '#fde68a', marginBottom: 4 }}>⚠ Possibly — {formatFallacyType(span.fallacy_type)}</div>
       <div style={{ color: '#fde68a', opacity: 0.75, fontStyle: 'italic', marginBottom: 10 }}>"{span.text}"</div>
       <div style={{ opacity: 0.65, lineHeight: 1.55, marginBottom: 4 }}>{span.explanation}</div>
       {span.if_legitimate && span.if_fallacy && (

--- a/frontend/src/components/ResolvedCard.tsx
+++ b/frontend/src/components/ResolvedCard.tsx
@@ -1,4 +1,5 @@
 import type { SpanResult, Resolution } from '../types'
+import { formatFallacyType } from '../utils/fallacyColors'
 interface Props { span: SpanResult; outcome: Resolution }
 export function ResolvedCard({ span, outcome }: Props) {
   const isConfirmed = outcome === 'CONFIRMED'
@@ -15,7 +16,7 @@ export function ResolvedCard({ span, outcome }: Props) {
           color: isConfirmed ? '#fca5a5' : '#86efac',
           border: `1px solid ${isConfirmed ? 'rgba(239,68,68,0.3)' : 'rgba(74,222,128,0.3)'}`,
         }}>
-          {isConfirmed ? `Confirmed — ${span.fallacy_type}` : 'Cleared — not a fallacy'}
+          {isConfirmed ? `Confirmed — ${formatFallacyType(span.fallacy_type)}` : 'Cleared — not a fallacy'}
         </span>
       </div>
       <div style={{ color: 'inherit', opacity: 0.5, fontStyle: 'italic', fontSize: '0.9em' }}>"{span.text}"</div>

--- a/frontend/src/utils/fallacyColors.ts
+++ b/frontend/src/utils/fallacyColors.ts
@@ -1,3 +1,7 @@
+export function formatFallacyType(t: string): string {
+  return t.replace(/\b\w/g, c => c.toUpperCase())
+}
+
 const BG: Record<string, string> = {
   'Ad Populum':            'rgba(239,68,68,0.25)',
   'Fallacy of Logic':      'rgba(167,139,250,0.25)',
@@ -14,5 +18,5 @@ const BORDER: Record<string, string> = {
   'Equivocation':          '#6366f1',
   'Fallacy of Credibility':'#f97316',
 }
-export const fallacyBg = (t: string) => BG[t] ?? 'rgba(148,163,184,0.2)'
-export const fallacyBorder = (t: string) => BORDER[t] ?? '#94a3b8'
+export const fallacyBg = (t: string) => BG[formatFallacyType(t)] ?? 'rgba(148,163,184,0.2)'
+export const fallacyBorder = (t: string) => BORDER[formatFallacyType(t)] ?? '#94a3b8'

--- a/frontend/src/utils/fallacyColors.ts
+++ b/frontend/src/utils/fallacyColors.ts
@@ -3,20 +3,34 @@ export function formatFallacyType(t: string): string {
 }
 
 const BG: Record<string, string> = {
-  'Ad Populum':            'rgba(239,68,68,0.25)',
-  'Fallacy of Logic':      'rgba(167,139,250,0.25)',
-  'Faulty Generalization': 'rgba(251,191,36,0.25)',
-  'Fallacy of Extension':  'rgba(52,211,153,0.25)',
-  'Equivocation':          'rgba(99,102,241,0.25)',
-  'Fallacy of Credibility':'rgba(249,115,22,0.25)',
+  'Ad Hominem':             'rgba(248,113,113,0.25)',
+  'Ad Populum':             'rgba(239,68,68,0.25)',
+  'Appeal To Emotion':      'rgba(244,114,182,0.25)',
+  'Circular Reasoning':     'rgba(129,140,248,0.25)',
+  'Equivocation':           'rgba(99,102,241,0.25)',
+  'Fallacy Of Credibility': 'rgba(249,115,22,0.25)',
+  'Fallacy Of Extension':   'rgba(52,211,153,0.25)',
+  'Fallacy Of Logic':       'rgba(167,139,250,0.25)',
+  'Fallacy Of Relevance':   'rgba(45,212,191,0.25)',
+  'False Causality':        'rgba(251,146,60,0.25)',
+  'False Dilemma':          'rgba(250,204,21,0.25)',
+  'Faulty Generalization':  'rgba(251,191,36,0.25)',
+  'Intentional':            'rgba(148,163,184,0.25)',
 }
 const BORDER: Record<string, string> = {
-  'Ad Populum':            '#ef4444',
-  'Fallacy of Logic':      '#a78bfa',
-  'Faulty Generalization': '#fbbf24',
-  'Fallacy of Extension':  '#34d399',
-  'Equivocation':          '#6366f1',
-  'Fallacy of Credibility':'#f97316',
+  'Ad Hominem':             '#f87171',
+  'Ad Populum':             '#ef4444',
+  'Appeal To Emotion':      '#f472b6',
+  'Circular Reasoning':     '#818cf8',
+  'Equivocation':           '#6366f1',
+  'Fallacy Of Credibility': '#f97316',
+  'Fallacy Of Extension':   '#34d399',
+  'Fallacy Of Logic':       '#a78bfa',
+  'Fallacy Of Relevance':   '#2dd4bf',
+  'False Causality':        '#fb923c',
+  'False Dilemma':          '#facc15',
+  'Faulty Generalization':  '#fbbf24',
+  'Intentional':            '#94a3b8',
 }
 export const fallacyBg = (t: string) => BG[formatFallacyType(t)] ?? 'rgba(148,163,184,0.2)'
 export const fallacyBorder = (t: string) => BORDER[formatFallacyType(t)] ?? '#94a3b8'


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant UI as Frontend
    participant API as /analyze (sync def)
    participant Pool as Thread Pool
    participant OAI as OpenAI (30s timeout)

    UI->>API: POST /analyze
    API->>Pool: run_in_threadpool(analyze)
    Pool->>OAI: chat.completions.parse (one attempt)
    alt OpenAI responds within 30s
        OAI-->>Pool: ExplainerOutput
        Pool-->>API: SpanResult[]
        API-->>UI: 200 AnalyzeResponse
    else timeout / error
        OAI-->>Pool: Exception
        Pool->>Pool: _fallback_content(spans)
        Pool-->>API: SpanResult[] (template content)
        API-->>UI: 200 AnalyzeResponse (degraded)
    end
```

```mermaid
graph LR
    FAISS["FAISS label<br/>'ad populum'"] -->|formatFallacyType| Display["Display<br/>'Ad Populum'"]
    FAISS -->|formatFallacyType| ColorMap["Color lookup<br/>BG['Ad Populum'] → red"]
```

## Summary

- Dataset labels are lowercase (`'ad populum'`) but the color map used title-case keys, so **all highlights showed fallback gray** — fixed by normalising through `formatFallacyType()` before map lookup and display
- `async def analyze` blocked FastAPI's event loop on the ML pipeline; changed to **`def analyze`** so FastAPI runs it in a thread pool, allowing concurrent requests
- Removed retry loop in the explainer (was doubling the effective timeout on failure) and set a **30-second OpenAI client timeout** to fail fast into template fallback

## Screenshots

N/A — color fix requires live server comparison, not static screenshots

## Test plan

- [ ] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — green
- [ ] `cd frontend && npm test` — green
- [ ] `cd frontend && npx tsc --noEmit` — no type errors
- [ ] New tests added for any new behavior
- [ ] (UI only) Manual smoke via dev servers — feature works in the browser

## Plan reference

Bug fixes discovered post-Task 14 during E2E testing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)