### PR TITLE
chore: remove stale plan reference from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,12 +61,6 @@ Human-authored PRs can drag-and-drop images directly into GitHub. -->
 - [ ] New tests added for any new behavior
 - [ ] (UI only) Manual smoke via dev servers — feature works in the browser
 
-## Plan reference
-
-<!-- Link the execution plan and task this PR implements. -->
-
-Task <N> from `docs/plans/2026-04-17-fallacy-watch-plan.md`.
-
 ---
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Removes the **Plan reference** section that pointed at `docs/plans/2026-04-17-fallacy-watch-plan.md`, which is not present in this repository.

## Test plan

- [x] N/A — template-only change

Made with [Cursor](https://cursor.com)