### PR TITLE
fix: challenge_types._MAP case mismatch — all fallbacks were returning non_sequitur

### DIFF
--- a/backend/pipeline/challenge_types.py
+++ b/backend/pipeline/challenge_types.py
@@ -9,7 +9,7 @@ _MAP: dict[str, str] = {
     "false dilemma":          "non_sequitur",
     "ad hominem":             "non_sequitur",
     "intentional":            "non_sequitur",
-    "miscellaneous":          "non_sequitur",
+    "miscellaneous":          "non_sequitur",  # defensive: not in current labels but safe forward-compat guard
     "ad populum":             "premise_check",
     "appeal to emotion":      "premise_check",
     "circular reasoning":     "premise_check",

--- a/backend/pipeline/challenge_types.py
+++ b/backend/pipeline/challenge_types.py
@@ -1,19 +1,19 @@
 _MAP: dict[str, str] = {
-    "Faulty Generalization":  "counterexample",
-    "False Causality":        "counterexample",
-    "Fallacy of Credibility": "domain_check",
-    "Equivocation":           "meaning_check",
-    "Fallacy of Extension":   "representation_check",
-    "Fallacy of Logic":       "non_sequitur",
-    "Fallacy of Relevance":   "non_sequitur",
-    "False Dilemma":          "non_sequitur",
-    "Ad Hominem":             "non_sequitur",
-    "Intentional":            "non_sequitur",
-    "Miscellaneous":          "non_sequitur",
-    "Ad Populum":             "premise_check",
-    "Appeal to Emotion":      "premise_check",
-    "Circular Reasoning":     "premise_check",
+    "faulty generalization":  "counterexample",
+    "false causality":        "counterexample",
+    "fallacy of credibility": "domain_check",
+    "equivocation":           "meaning_check",
+    "fallacy of extension":   "representation_check",
+    "fallacy of logic":       "non_sequitur",
+    "fallacy of relevance":   "non_sequitur",
+    "false dilemma":          "non_sequitur",
+    "ad hominem":             "non_sequitur",
+    "intentional":            "non_sequitur",
+    "miscellaneous":          "non_sequitur",
+    "ad populum":             "premise_check",
+    "appeal to emotion":      "premise_check",
+    "circular reasoning":     "premise_check",
 }
 
 def challenge_type_for(fallacy_type: str) -> str:
-    return _MAP.get(fallacy_type, "non_sequitur")
+    return _MAP.get(fallacy_type.lower(), "non_sequitur")

--- a/backend/tests/test_challenge_types.py
+++ b/backend/tests/test_challenge_types.py
@@ -1,12 +1,23 @@
+import pytest
 from pipeline.challenge_types import challenge_type_for
 
-def test_known_mappings():
-    assert challenge_type_for("Faulty Generalization") == "counterexample"
-    assert challenge_type_for("Fallacy of Credibility") == "domain_check"
-    assert challenge_type_for("Equivocation") == "meaning_check"
-    assert challenge_type_for("Fallacy of Extension") == "representation_check"
-    assert challenge_type_for("False Dilemma") == "non_sequitur"
-    assert challenge_type_for("Ad Populum") == "premise_check"
-
-def test_unknown_type_returns_non_sequitur():
-    assert challenge_type_for("unknown") == "non_sequitur"
+@pytest.mark.parametrize("label,expected", [
+    # 13 runtime labels (all lowercase, as produced by classifier.py)
+    ("ad populum",             "premise_check"),
+    ("appeal to emotion",      "premise_check"),
+    ("circular reasoning",     "premise_check"),
+    ("faulty generalization",  "counterexample"),
+    ("false causality",        "counterexample"),
+    ("fallacy of credibility", "domain_check"),
+    ("equivocation",           "meaning_check"),
+    ("fallacy of extension",   "representation_check"),
+    ("fallacy of logic",       "non_sequitur"),
+    ("fallacy of relevance",   "non_sequitur"),
+    ("false dilemma",          "non_sequitur"),
+    ("ad hominem",             "non_sequitur"),
+    ("intentional",            "non_sequitur"),
+    # 1 synthetic default case
+    ("unknown label",          "non_sequitur"),
+])
+def test_challenge_type_for(label: str, expected: str) -> None:
+    assert challenge_type_for(label) == expected

--- a/backend/tests/test_challenge_types.py
+++ b/backend/tests/test_challenge_types.py
@@ -16,7 +16,9 @@ from pipeline.challenge_types import challenge_type_for
     ("false dilemma",          "non_sequitur"),
     ("ad hominem",             "non_sequitur"),
     ("intentional",            "non_sequitur"),
-    # 1 synthetic default case
+    # 1 defensive entry (not a runtime label, kept for forward-compat)
+    ("miscellaneous",          "non_sequitur"),
+    # 1 synthetic default case — 13 runtime + 1 defensive + 1 unknown default = 15 total
     ("unknown label",          "non_sequitur"),
 ])
 def test_challenge_type_for(label: str, expected: str) -> None:

--- a/frontend/src/components/__tests__/ResolvedCard.test.tsx
+++ b/frontend/src/components/__tests__/ResolvedCard.test.tsx
@@ -1,12 +1,17 @@
 import { render, screen } from '@testing-library/react'
+import type { SpanResult } from '../../types'
 import { ResolvedCard } from '../ResolvedCard'
 
 const span = {
   id: 'span_0', text: 'All experts agree', start: 0, end: 17,
   status: 'confirmed' as const, fallacy_type: 'ad populum',
-  explanation: 'Appeals to consensus.', challenge: null as any,
+  explanation: 'Appeals to consensus.',
+  challenge: {
+    type: 'premise_check' as const,
+    question: { text: 'Is this a stub?', yes_label: 'Yes', no_label: 'No' },
+  },
   if_legitimate: null, if_fallacy: null, content_generated: true,
-}
+} satisfies SpanResult
 
 test('displays fallacy type in Title Case', () => {
   render(<ResolvedCard span={span} outcome="CONFIRMED" />)

--- a/frontend/src/components/__tests__/ResolvedCard.test.tsx
+++ b/frontend/src/components/__tests__/ResolvedCard.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react'
+import { ResolvedCard } from '../ResolvedCard'
+
+const span = {
+  id: 'span_0', text: 'All experts agree', start: 0, end: 17,
+  status: 'confirmed' as const, fallacy_type: 'ad populum',
+  explanation: 'Appeals to consensus.', challenge: null as any,
+  if_legitimate: null, if_fallacy: null, content_generated: true,
+}
+
+test('displays fallacy type in Title Case', () => {
+  render(<ResolvedCard span={span} outcome="CONFIRMED" />)
+  expect(screen.getByText(/Ad Populum/)).toBeInTheDocument()
+})


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    direction LR

    state "Before fix (Title Case keys)" as Before {
        [*] --> lookup
        lookup : _MAP.get(fallacy_type)
        lookup --> non_sequitur : "ad populum" ≠ "Ad Populum" → miss
        lookup --> non_sequitur : "faulty generalization" ≠ "Faulty Generalization" → miss
        lookup --> non_sequitur : all non-sequitur keys → accidental hit
    }

    state "After fix (lowercase keys + .lower())" as After {
        [*] --> normalise
        normalise : fallacy_type.lower()
        normalise --> lookup2
        lookup2 : _MAP.get(normalised)
        lookup2 --> premise_check : "ad populum" ✓
        lookup2 --> counterexample : "faulty generalization" ✓
        lookup2 --> domain_check : "fallacy of credibility" ✓
        lookup2 --> meaning_check : "equivocation" ✓
        lookup2 --> representation_check : "fallacy of extension" ✓
        lookup2 --> non_sequitur : intentional / unknown / etc.
    }
```

## Summary

- `challenge_types._MAP` used Title Case keys (`"Ad Populum"`) while the classifier produces all-lowercase labels (`"ad populum"`), causing every non-`non_sequitur` challenge to silently fall back to `non_sequitur`
- Fixed by lowercasing all `_MAP` keys and calling `.lower()` on the lookup input in `challenge_type_for`
- Added a `ResolvedCard` regression test confirming `formatFallacyType` produces Title Case for display (the function call was already present; test cements the contract)

## Screenshots

N/A — not UI

## Test plan

- ✅ `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — 28 passed (2 pre-existing failures in test_api.py due to missing `en_core_web_sm` model, unrelated to this change)
- ✅ `cd frontend && npx vitest run` — 14 passed (4 test files)
- ✅ `cd frontend && npx tsc --noEmit` — no type errors
- ✅ New parametrised test covers all 13 runtime labels + 1 synthetic default (14 cases total)
- ✅ New `ResolvedCard.test.tsx` verifies Title Case display for a lowercase `fallacy_type`

---

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)