### PR TITLE
fix: activate cascade overwrites resolved spans — add guard in useFallacyCollection

### DIFF
--- a/e2e/fixtures/activate-pair.json
+++ b/e2e/fixtures/activate-pair.json
@@ -1,0 +1,42 @@
+{
+  "spans": [
+    {
+      "id": "span_0",
+      "text": "First claim",
+      "start": 0, "end": 11,
+      "status": "confirmed",
+      "fallacy_type": "Ad Populum",
+      "explanation": "Appeals to consensus.",
+      "challenge": {
+        "type": "premise_check",
+        "question": { "text": "Is this a fallacy?", "yes_label": "Yes fallacy", "no_label": "Not a fallacy" }
+      },
+      "if_legitimate": null, "if_fallacy": null, "content_generated": true
+    },
+    {
+      "id": "span_1",
+      "text": "Second claim",
+      "start": 13, "end": 25,
+      "status": "possibly",
+      "fallacy_type": "Circular Reasoning",
+      "explanation": "Circular.",
+      "challenge": {
+        "type": "premise_check",
+        "question": { "text": "Is this circular?", "yes_label": "Yes circular", "no_label": "Not circular" }
+      },
+      "if_legitimate": "The conclusion stands independently.",
+      "if_fallacy": "The argument is circular.",
+      "content_generated": true
+    }
+  ],
+  "rules": [
+    {
+      "source_id": "span_0",
+      "dependent_id": "span_1",
+      "when": "CONFIRMED",
+      "effect": "activate",
+      "reason": "First confirms second needs review."
+    }
+  ],
+  "meta": { "sentence_count": 1, "argument_span_count": 2, "fallacy_count": 2, "processing_ms": 55 }
+}

--- a/e2e/specs/activate-cascade.spec.ts
+++ b/e2e/specs/activate-cascade.spec.ts
@@ -15,6 +15,7 @@ test.describe('activate cascade', () => {
 
     // Now resolve span_0 — this fires the activate rule targeting span_1
     await app.cardConfirmed('span_0').getByRole('button', { name: 'Yes fallacy' }).click()
+    await expect(app.cardResolved('span_0')).toBeVisible()
 
     // span_1 must STILL be resolved — activate must not overwrite it
     await expect(app.cardResolved('span_1')).toBeVisible()

--- a/e2e/specs/activate-cascade.spec.ts
+++ b/e2e/specs/activate-cascade.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/AppPage'
+import activatePair from '../fixtures/activate-pair.json'
+
+test.describe('activate cascade', () => {
+  test('activate cascade does not overwrite a previously resolved span', async ({ page }) => {
+    const app = new AppPage(page)
+    await app.mockAnalyze(activatePair)
+    await app.goto()
+    await app.fillAndAnalyze('First claim. Second claim.')
+
+    // Resolve span_1 first (the activate target)
+    await app.cardPossibly('span_1').getByRole('button', { name: 'Not circular' }).click()
+    await expect(app.cardResolved('span_1')).toBeVisible()
+
+    // Now resolve span_0 — this fires the activate rule targeting span_1
+    await app.cardConfirmed('span_0').getByRole('button', { name: 'Yes fallacy' }).click()
+
+    // span_1 must STILL be resolved — activate must not overwrite it
+    await expect(app.cardResolved('span_1')).toBeVisible()
+    await expect(app.cardPossibly('span_1')).not.toBeVisible()
+  })
+})

--- a/frontend/src/hooks/useFallacyCollection.ts
+++ b/frontend/src/hooks/useFallacyCollection.ts
@@ -43,7 +43,11 @@ export function useFallacyCollection(
       const cascades = getCascades(id, outcome)
       setResolutions(prev => {
         const next = { ...prev, [id]: outcome }
-        for (const c of cascades) next[c.id] = c.resolution
+        for (const c of cascades) {
+          // activate must not overwrite a user decision; moot correctly overrides
+          if (c.resolution === 'PENDING' && (prev[c.id] === 'CONFIRMED' || prev[c.id] === 'CLEARED')) continue
+          next[c.id] = c.resolution
+        }
         return next
       })
       return cascades


### PR DESCRIPTION
## Diagrams

```mermaid
stateDiagram-v2
    direction LR

    state "BUG (before)" as bug {
        [*] --> PENDING
        PENDING --> CONFIRMED : user resolves span_1
        CONFIRMED --> PENDING : activate cascade fires\n(overwrites user decision)
    }

    state "FIXED (after)" as fixed {
        [*] --> PENDING2
        PENDING2 --> CONFIRMED2 : user resolves span_1
        CONFIRMED2 --> CONFIRMED2 : activate cascade fires\n(guard skips — already resolved)
    }
```

The guard lives inside `resolve()`'s `setResolutions` updater where `prev` state is available. It skips writing `PENDING` for any span already in `CONFIRMED` or `CLEARED`. `moot` is intentionally exempt — it correctly overrides regardless.

## Summary

- `getCascades` mapped `activate` rules to `'PENDING'` unconditionally; when a later `activate` cascade fired on an already-resolved span the user's decision was silently erased.
- Added a guard in `resolve()` that skips applying an `activate`-generated `PENDING` if the target span is already `CONFIRMED` or `CLEARED`.
- `moot` cascades are unaffected — moot correctly overrides any prior state.

## Screenshots

N/A — not UI

## Test plan

- ✅ `cd e2e && npx playwright test specs/activate-cascade.spec.ts` — new spec passes
- ✅ `cd e2e && npx playwright test` — all 22 E2E tests pass, no regressions
- ✅ `cd frontend && npx tsc --noEmit` — zero TypeScript errors

## Plan reference

Closes #18