### PR TITLE
test: E2E spec — clicking inline highlight scrolls to its finding card

### DIFF
--- a/e2e/fixtures/cascade-pair.json
+++ b/e2e/fixtures/cascade-pair.json
@@ -23,8 +23,8 @@
     {
       "id": "span_1",
       "text": "this proves our point",
-      "start": 30,
-      "end": 51,
+      "start": 22,
+      "end": 43,
       "status": "possibly",
       "fallacy_type": "circular reasoning",
       "explanation": "The argument loops back on itself.",

--- a/e2e/specs/highlight-interaction.spec.ts
+++ b/e2e/specs/highlight-interaction.spec.ts
@@ -3,11 +3,8 @@ import { AppPage } from '../pages/AppPage'
 import cascadePair from '../fixtures/cascade-pair.json'
 
 test.describe('highlight interaction', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 300 })
-  })
-
   test('clicking span_1 highlight scrolls to its card', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 300 })
     const app = new AppPage(page)
     await app.mockAnalyze(cascadePair)
     await app.goto()
@@ -19,6 +16,7 @@ test.describe('highlight interaction', () => {
   })
 
   test('clicking span_0 highlight scrolls to its card', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 300 })
     const app = new AppPage(page)
     await app.mockAnalyze(cascadePair)
     await app.goto()

--- a/e2e/specs/highlight-interaction.spec.ts
+++ b/e2e/specs/highlight-interaction.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/AppPage'
+import cascadePair from '../fixtures/cascade-pair.json'
+
+test.describe('highlight interaction', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 300 })
+  })
+
+  test('clicking span_1 highlight scrolls to its card', async ({ page }) => {
+    const app = new AppPage(page)
+    await app.mockAnalyze(cascadePair)
+    await app.goto()
+    await app.fillAndAnalyze('Every scientist knows this proves our point.')
+
+    await app.highlight('this proves our point').click()
+
+    await expect(app.cardPossibly('span_1')).toBeInViewport()
+  })
+
+  test('clicking span_0 highlight scrolls to its card', async ({ page }) => {
+    const app = new AppPage(page)
+    await app.mockAnalyze(cascadePair)
+    await app.goto()
+    await app.fillAndAnalyze('Every scientist knows this proves our point.')
+
+    await app.highlight('Every scientist knows').click()
+
+    await expect(app.cardConfirmed('span_0')).toBeInViewport()
+  })
+})


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant DOM

    User->>Frontend: clicks highlight span
    Frontend->>DOM: scrollIntoView()
    DOM->>DOM: scroll to card element
    Frontend->>Frontend: verify card in viewport
```

## Summary

- Tests that clicking an inline highlight button scrolls the corresponding finding card into viewport
- Covers both span states: `confirmed` (span_0) and `possibly` (span_1)
- Verifies the smooth scroll behavior works correctly with small viewport (1280×300)

## Screenshots

N/A — not UI

## Test plan

✅ `npx playwright test specs/highlight-interaction.spec.ts` — 2/2 pass
✅ `npx playwright test` — all 23 pass
✅ `npx tsc --noEmit` — 0 errors

## Notes

Fixed `cascade-pair.json` fixture to have correct span indices (span_1 was positioned at 30-51 but should be 22-43 for the test text "Every scientist knows this proves our point.").

Closes #20