### PR TITLE
test: E2E spec — re-analyze resets all resolution state

### DIFF
--- a/e2e/specs/reanalyze.spec.ts
+++ b/e2e/specs/reanalyze.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+import { AppPage } from '../pages/AppPage'
+import singleConfirmed from '../fixtures/single-confirmed.json'
+import emptyResult from '../fixtures/empty-result.json'
+
+test.describe('re-analyze', () => {
+  test('re-analyzing clears previous resolutions', async ({ page }) => {
+    const app = new AppPage(page)
+
+    // First analysis
+    await app.mockAnalyze(singleConfirmed)
+    await app.goto()
+    await app.fillAndAnalyze('All experts agree that this is true.')
+    await expect(app.cardConfirmed('span_0')).toBeVisible()
+
+    // Resolve the card
+    await app.cardConfirmed('span_0')
+      .getByRole('button', { name: 'It is a fallacy' })
+      .click()
+    await expect(app.cardResolved('span_0')).toBeVisible()
+
+    // Re-mock and re-analyze
+    await app.mockAnalyze(singleConfirmed)
+    await app.textarea.fill('Every expert knows this.')
+    await app.analyzeButton.click()
+    await expect(app.metaLine).toContainText('1 finding')
+
+    // Previous resolved card must be gone; new card must be unresolved
+    await expect(app.cardResolved('span_0')).not.toBeVisible()
+    await expect(app.cardConfirmed('span_0')).toBeVisible()
+  })
+
+  test('re-analyzing with empty result clears previous findings', async ({ page }) => {
+    const app = new AppPage(page)
+    await app.mockAnalyze(singleConfirmed)
+    await app.goto()
+    await app.fillAndAnalyze('All experts agree.')
+    await expect(app.cardConfirmed('span_0')).toBeVisible()
+
+    await app.mockAnalyze(emptyResult)
+    await app.textarea.fill('The sky is blue.')
+    await app.analyzeButton.click()
+    await expect(app.noFallaciesMessage).toBeVisible()
+    await expect(app.cardConfirmed('span_0')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant User
    participant App
    participant Backend

    User->>App: 1. Analyze "All experts agree..."
    App->>Backend: POST /analyze
    Backend-->>App: { spans: [span_0:confirmed] }
    App->>App: Render span_0 with card

    User->>App: 2. Click "It is a fallacy"
    App->>App: Update span_0 to resolved state
    App->>App: Render card-resolved-span_0

    User->>App: 3. Change text, click Analyze
    App->>App: Reset all spans to initial state
    App->>Backend: POST /analyze
    Backend-->>App: { spans: [span_0:confirmed] }
    App->>App: Render NEW span_0 with card (unresolved)
    App->>App: card-resolved-span_0 no longer visible
```

## Summary

- Creates `e2e/specs/reanalyze.spec.ts` with two E2E test cases
- **Test 1:** Verifies re-analyzing clears previous resolution state (resolved → unresolved)
- **Test 2:** Verifies re-analyzing with empty result clears all previous findings
- All 25 E2E tests pass; no TypeScript compilation errors

## Screenshots

N/A — not UI

## Test plan

- ✅ `cd e2e && npx playwright test specs/reanalyze.spec.ts` — both tests pass
- ✅ `cd e2e && npx playwright test` — all 25 tests pass
- ✅ `cd frontend && npx tsc --noEmit` — no TypeScript errors

Closes #21