### PR TITLE
test: E2E spec — PossiblyCard LegitimacyComparison renders both columns

### DIFF
--- a/e2e/specs/challenge-resolution.spec.ts
+++ b/e2e/specs/challenge-resolution.spec.ts
@@ -46,5 +46,46 @@ test.describe('challenge resolution', () => {
       await expect(app.cardPossibly('span_1')).not.toBeVisible()
       await expect(app.cardResolved('span_1')).toBeVisible()
     })
+
+    test('shows both if_legitimate and if_fallacy columns with text', async () => {
+      const card = app.cardPossibly('span_1')
+
+      await expect(card.getByText('IF LEGITIMATE', { exact: false })).toBeVisible()
+      await expect(card.getByText('IF A FALLACY', { exact: false })).toBeVisible()
+
+      await expect(card.getByText('The conclusion stands independently.')).toBeVisible()
+      await expect(card.getByText('The argument is circular.')).toBeVisible()
+    })
+  })
+
+  test('does not show legitimacy comparison when fields are null', async ({ page }) => {
+    const app = new AppPage(page)
+    const possiblyNoComparison = {
+      spans: [{
+        id: 'span_0',
+        text: 'All experts agree',
+        start: 0, end: 17,
+        status: 'possibly',
+        fallacy_type: 'Ad Populum',
+        explanation: 'Appeals to consensus.',
+        challenge: {
+          type: 'premise_check',
+          question: { text: 'Is this a fallacy?', yes_label: 'Yes', no_label: 'No' }
+        },
+        if_legitimate: null,
+        if_fallacy: null,
+        content_generated: true,
+      }],
+      rules: [],
+      meta: { sentence_count: 1, argument_span_count: 1, fallacy_count: 1, processing_ms: 10 },
+    } as Parameters<typeof app.mockAnalyze>[0]
+    await app.mockAnalyze(possiblyNoComparison)
+    await app.goto()
+    await app.fillAndAnalyze('All experts agree.')
+
+    await expect(app.cardPossibly('span_0')).toBeVisible()
+    await expect(
+      app.cardPossibly('span_0').getByText('IF LEGITIMATE', { exact: false })
+    ).not.toBeVisible()
   })
 })

--- a/e2e/specs/challenge-resolution.spec.ts
+++ b/e2e/specs/challenge-resolution.spec.ts
@@ -78,7 +78,7 @@ test.describe('challenge resolution', () => {
       }],
       rules: [],
       meta: { sentence_count: 1, argument_span_count: 1, fallacy_count: 1, processing_ms: 10 },
-    } as Parameters<typeof app.mockAnalyze>[0]
+    }
     await app.mockAnalyze(possiblyNoComparison)
     await app.goto()
     await app.fillAndAnalyze('All experts agree.')
@@ -86,6 +86,9 @@ test.describe('challenge resolution', () => {
     await expect(app.cardPossibly('span_0')).toBeVisible()
     await expect(
       app.cardPossibly('span_0').getByText('IF LEGITIMATE', { exact: false })
+    ).not.toBeVisible()
+    await expect(
+      app.cardPossibly('span_0').getByText('IF A FALLACY', { exact: false })
     ).not.toBeVisible()
   })
 })


### PR DESCRIPTION
## Diagrams

```mermaid
graph TD
    PC["PossiblyCard"]
    LC["LegitimacyComparison"]
    COL1["✓ IF LEGITIMATE<br/>(when populated)"]
    COL2["✗ IF A FALLACY<br/>(when populated)"]
    
    PC -->|if_legitimate && if_fallacy| LC
    LC --> COL1
    LC --> COL2
    
    style PC fill:#3a7ca5
    style LC fill:#6bb6d6
    style COL1 fill:#4ade80
    style COL2 fill:#ef4444
```

## Summary

- Added E2E test verifying both `IF LEGITIMATE` and `IF A FALLACY` columns render with their respective text content when populated in cascade-pair fixture
- Added E2E test confirming `LegitimacyComparison` does not render when both `if_legitimate` and `if_fallacy` fields are null
- All 29 E2E tests pass; TypeScript compilation clean (zero errors)

## Screenshots

N/A — not UI

## Test plan

- [x] `cd e2e && npx playwright test specs/challenge-resolution.spec.ts` — 6/6 tests pass
- [x] `cd e2e && npx playwright test` — 29/29 tests pass
- [x] `cd frontend && npx tsc --noEmit` — zero errors

## Plan reference

Closes #23