### PR TITLE
chore: surface Python as GitHub primary language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude frontend + e2e from GitHub's linguist detection so the NLP
+# pipeline (Python) is shown as the repo's primary language instead of
+# the Vite/Playwright TypeScript that dominates by byte count. The
+# backend is the distinctive code; the frontend is a thin SPA over it.
+frontend/** linguist-detectable=false
+e2e/** linguist-detectable=false


### PR DESCRIPTION
## Diagrams

N/A — single-file config change.

## Summary

- Adds `.gitattributes` marking `frontend/**` and `e2e/**` as `linguist-detectable=false` so GitHub reports Python as the repo's primary language instead of TypeScript.
- Motivation: the Python NLP pipeline (`backend/pipeline/`) is the distinctive code; the TS frontend is a thin Vite SPA and the e2e dir is Playwright specs. Linguist counts bytes and was picking TypeScript (41 KB) over Python (27 KB).
- Side effect: the "Languages" bar on the repo page will also simplify to Python-only. The stack is still surfaced via the README, the repo description, and the `python` + `typescript` topics.

## Screenshots

N/A — not UI.

## Test plan

- [ ] N/A — config-only, no code paths affected (pytest / vitest / tsc unchanged)
- [x] GitHub re-scan after merge will flip the pinned-repo card from "TypeScript" to "Python"

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)