### PR TITLE
chore: backend tooling foundation — ruff config, pyright in CI, env example, deps

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -23,4 +23,5 @@ jobs:
           source .venv/bin/activate
           python -m spacy download en_core_web_sm
           ruff check .
+          pyright
           pytest tests/ -v -m "not slow"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,7 @@ Outputs `backend/data/logical_fallacy.index` and `backend/data/logical_fallacy_l
 - TypeScript: strict mode, no `any`, Vitest for tests
 - No comments explaining what the code does — only comments explaining non-obvious WHY
 - TDD: write failing test first, implement to pass, then commit
+
+### Type-checking (pyright)
+
+`pyright` runs in CI with `typeCheckingMode = "standard"` (config in `backend/pyproject.toml`). Standard, not `strict`, because spaCy/transformers/faiss ship limited stubs and `strict` would force noise-suppression at every third-party boundary. Tighten to `strict` once stubs improve or once we wrap external libs in typed adapters. `# pyright: ignore[<rule>]` comments must include a one-line justification (no bare ignores).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,14 @@
+# Required for GPT-4o mini explainer step. App falls back to template content if missing.
+OPENAI_API_KEY=
+
+# Optional. Concurrency limit for /analyze (default: 2). See main.py.
+# ANALYZE_MAX_CONCURRENT=2
+
+# Optional. Max characters in OpenAI prompt before falling back to template (default: 50000).
+# EXPLAINER_MAX_PAYLOAD_CHARS=50000
+
+# Optional. Max output tokens for the OpenAI parse call (default: 2000).
+# EXPLAINER_MAX_OUTPUT_TOKENS=2000
+
+# Optional. Per-IP rate limit for /analyze (default: "10/minute"). Format: slowapi.
+# ANALYZE_RATE_LIMIT=10/minute

--- a/backend/data/build_index.py
+++ b/backend/data/build_index.py
@@ -1,9 +1,10 @@
 import json
 import pathlib
-import numpy as np
-from sentence_transformers import SentenceTransformer
-from datasets import load_dataset
+
 import faiss
+import numpy as np
+from datasets import load_dataset
+from sentence_transformers import SentenceTransformer
 
 DATA_DIR = pathlib.Path(__file__).parent
 

--- a/backend/data/build_index.py
+++ b/backend/data/build_index.py
@@ -44,7 +44,8 @@ def build():
 
     print("Building FAISS index...")
     index = faiss.IndexFlatIP(embeddings.shape[1])
-    index.add(embeddings)
+    # faiss has no type stubs; .add(x) signature is inferred incorrectly
+    index.add(embeddings)  # pyright: ignore[reportCallIssue]
 
     faiss.write_index(index, str(DATA_DIR / "logical_fallacy.index"))
     (DATA_DIR / "logical_fallacy_labels.json").write_text(json.dumps(labels))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,21 @@
 import time
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+
 from models.span import (
-    AnalyzeRequest, AnalyzeResponse, SpanResult,
-    Challenge, Question, ChallengeType, DependencyRule, AnalysisMeta,
+    AnalysisMeta,
+    AnalyzeRequest,
+    AnalyzeResponse,
+    Challenge,
+    ChallengeType,
+    DependencyRule,
+    Question,
+    SpanResult,
 )
-from pipeline.segmenter import get_argument_spans, _nlp
 from pipeline.classifier import classify_spans
-from pipeline.explainer import generate_content, _fallback_content
+from pipeline.explainer import _fallback_content, generate_content
+from pipeline.segmenter import _nlp, get_argument_spans
 
 app = FastAPI()
 app.add_middleware(

--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
-class Resolution(str, Enum):
+
+class Resolution(StrEnum):
     PENDING   = "PENDING"
     CONFIRMED = "CONFIRMED"
     CLEARED   = "CLEARED"
@@ -39,7 +41,9 @@ class FallacyCollection:
                     cascades.append((rule.dependent_id, Resolution.MOOT, rule.reason))
         return cascades
 
-    def preview_cascade(self, span_id: str, outcome: Resolution) -> list[tuple[str, Resolution, str]]:
+    def preview_cascade(
+        self, span_id: str, outcome: Resolution,
+    ) -> list[tuple[str, Resolution, str]]:
         return [
             (r.dependent_id, Resolution.MOOT, r.reason)
             for r in self.rules

--- a/backend/models/span.py
+++ b/backend/models/span.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
-from enum import Enum
-from typing import Optional, Literal
+
+from enum import StrEnum
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
-class ChallengeType(str, Enum):
+
+class ChallengeType(StrEnum):
     COUNTEREXAMPLE       = "counterexample"
     DOMAIN_CHECK         = "domain_check"
     MEANING_CHECK        = "meaning_check"
@@ -36,8 +39,8 @@ class SpanResult(BaseModel):
     fallacy_type: str
     explanation: str
     challenge: Challenge
-    if_legitimate: Optional[str] = None
-    if_fallacy: Optional[str] = None
+    if_legitimate: str | None = None
+    if_fallacy: str | None = None
     content_generated: bool = True
 
 class AnalysisMeta(BaseModel):
@@ -78,8 +81,8 @@ class ExplainerSpan(BaseModel):
     id: str
     explanation: str
     challenge: ExplainerChallenge
-    if_legitimate: Optional[str] = None
-    if_fallacy: Optional[str] = None
+    if_legitimate: str | None = None
+    if_fallacy: str | None = None
 
 class ExplainerOutput(BaseModel):
     spans: list[ExplainerSpan]

--- a/backend/pipeline/challenge_types.py
+++ b/backend/pipeline/challenge_types.py
@@ -9,7 +9,8 @@ _MAP: dict[str, str] = {
     "false dilemma":          "non_sequitur",
     "ad hominem":             "non_sequitur",
     "intentional":            "non_sequitur",
-    "miscellaneous":          "non_sequitur",  # defensive: not in current labels but safe forward-compat guard
+    # defensive: not in current labels but safe forward-compat guard
+    "miscellaneous":          "non_sequitur",
     "ad populum":             "premise_check",
     "appeal to emotion":      "premise_check",
     "circular reasoning":     "premise_check",

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -1,9 +1,10 @@
 import json
 import pathlib
-import numpy as np
 from functools import lru_cache
-from sentence_transformers import SentenceTransformer
+
 import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
 
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 CONFIDENCE_THRESHOLD = 0.82
@@ -27,7 +28,7 @@ def classify_spans(spans: list[dict]) -> list[dict]:
     embeddings = np.array(embeddings, dtype="float32")
     distances, indices = index.search(embeddings, k=1)
     result = []
-    for span, dist, idx in zip(spans, distances, indices):
+    for span, dist, idx in zip(spans, distances, indices, strict=True):
         confidence = float(dist[0])
         result.append({
             **span,

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import os
+
 from openai import OpenAI
-from models.span import (ExplainerOutput, ExplainerSpan, ExplainerChallenge,
-                          ExplainerQuestion)
+
+from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
 from pipeline.challenge_types import challenge_type_for
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ and an assigned fallacy_type. Generate:
 - if_fallacy: one sentence — what this looks like if it is a fallacy
 
 Also return dependency_rules if any span's challenge only makes sense after another's resolution.
-Never reclassify the assigned fallacy_type."""
+Never reclassify the assigned fallacy_type."""  # noqa: E501
 
 _TEMPLATE_QUESTIONS = {
     "counterexample":       ("Can you name a single instance that disproves this universal claim?",

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -1,11 +1,17 @@
 import json
 import logging
 import os
+from typing import Literal, cast
 
 from openai import OpenAI
 
 from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
 from pipeline.challenge_types import challenge_type_for
+
+ChallengeTypeLiteral = Literal[
+    "counterexample", "domain_check", "meaning_check",
+    "representation_check", "non_sequitur", "premise_check",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +52,9 @@ _TEMPLATE_QUESTIONS = {
 def _fallback_content(spans: list[dict]) -> ExplainerOutput:
     result_spans = []
     for span in spans:
-        ct = challenge_type_for(span["fallacy_type"])
+        # challenge_type_for returns one of the keys of _TEMPLATE_QUESTIONS,
+        # which is exactly ChallengeTypeLiteral; cast to the narrower type.
+        ct = cast(ChallengeTypeLiteral, challenge_type_for(span["fallacy_type"]))
         q_text, yes_lbl, no_lbl = _TEMPLATE_QUESTIONS[ct]
         result_spans.append(ExplainerSpan(
             id=span["id"],
@@ -85,6 +93,8 @@ def generate_content(
         msg = response.choices[0].message
         if msg.refusal:
             raise ValueError(f"Model refused: {msg.refusal}")
+        if msg.parsed is None:
+            raise ValueError("Model returned no parsed output")
         return msg.parsed
     except Exception as e:
         logger.warning("explainer failed: %s", e, exc_info=True)

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -1,6 +1,8 @@
+from functools import lru_cache
+
 import spacy
 from transformers import pipeline as hf_pipeline
-from functools import lru_cache
+
 
 @lru_cache(maxsize=1)
 def _nlp():
@@ -23,8 +25,9 @@ def get_argument_spans(text: str) -> list[dict]:
         return []
     texts = [s.text for s in sentences]
     labels = _arg_classifier()(texts, batch_size=16, truncation=True)
+    # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT"
     return [
         {"text": sent.text, "start": sent.start_char, "end": sent.end_char}
-        for sent, label in zip(sentences, labels)
-        if label["label"] == "ARGUMENT"   # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT"
+        for sent, label in zip(sentences, labels, strict=True)
+        if label["label"] == "ARGUMENT"
     ]

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -25,9 +25,11 @@ def get_argument_spans(text: str) -> list[dict]:
         return []
     texts = [s.text for s in sentences]
     labels = _arg_classifier()(texts, batch_size=16, truncation=True)
-    # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT"
+    # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT".
+    # transformers stubs type the pipeline return as a broad union (incl. None);
+    # at runtime it's a list[dict[str, str]] when called with a list of strings.
     return [
         {"text": sent.text, "start": sent.start_char, "end": sent.end_char}
-        for sent, label in zip(sentences, labels, strict=True)
+        for sent, label in zip(sentences, labels, strict=True)  # pyright: ignore[reportArgumentType]
         if label["label"] == "ARGUMENT"
     ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",     # pycodestyle errors
+    "F",     # pyflakes
+    "I",     # isort
+    "B",     # flake8-bugbear
+    "UP",    # pyupgrade
+    "S",     # flake8-bandit (security)
+    "ASYNC", # flake8-async
+    "PL",    # pylint (subset)
+]
+ignore = [
+    "S101",    # assert used — fine in tests
+    "PLR0913", # too many args — opinions vary
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101", "S105", "S106"]  # assert + fake passwords are fine in tests
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,3 +27,12 @@ ignore = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.pyright]
+include = ["main.py", "models", "pipeline", "data"]
+exclude = ["**/__pycache__", "tests"]
+pythonVersion = "3.11"
+typeCheckingMode = "standard"
+reportMissingImports = "error"
+reportMissingTypeStubs = "warning"
+reportPrivateUsage = "warning"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "S105", "S106"]  # assert + fake passwords are fine in tests
+# tests: assert + fake passwords are fine; magic comparisons (status codes,
+# fixture sizes) and lazy imports for monkeypatching are conventional in
+# pytest code.
+"tests/*" = ["S101", "S105", "S106", "PLR2004", "PLC0415", "E501"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 ruff>=0.4.0
 pytest>=8.2.0
 pytest-asyncio>=0.23.0
+pyright>=1.1.350

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,10 @@
 fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.7.0
-spacy>=3.7.0,<3.8.0
+spacy>=3.7.0
 sentence-transformers>=3.0.0
 faiss-cpu>=1.7.4
-transformers>=4.37.0,<4.51.0
+transformers>=4.37.0
 torch>=2.1.0
 openai>=1.30.0
 datasets>=2.19.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,7 +1,10 @@
 from unittest.mock import patch
+
 import pytest
-from httpx import AsyncClient, ASGITransport
-from models.span import ExplainerOutput, ExplainerSpan, ExplainerChallenge, ExplainerQuestion
+from httpx import ASGITransport, AsyncClient
+
+from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
+
 
 def _mock_explainer_output():
     return ExplainerOutput(

--- a/backend/tests/test_challenge_types.py
+++ b/backend/tests/test_challenge_types.py
@@ -1,5 +1,7 @@
 import pytest
+
 from pipeline.challenge_types import challenge_type_for
+
 
 @pytest.mark.parametrize("label,expected", [
     # 13 runtime labels (all lowercase, as produced by classifier.py)

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pipeline.classifier import classify_spans
 
 
@@ -21,8 +22,9 @@ def test_preserves_original_keys():
 
 
 def test_threshold_determines_status(monkeypatch):
-    import numpy as np
     import types
+
+    import numpy as np
 
     fake_model = types.SimpleNamespace(
         encode=lambda texts, **kw: np.array([[1.0] * 768], dtype="float32")

--- a/backend/tests/test_collection.py
+++ b/backend/tests/test_collection.py
@@ -1,4 +1,5 @@
-from models.collection import FallacyCollection, Resolution, Span, DependencyRule
+from models.collection import DependencyRule, FallacyCollection, Resolution, Span
+
 
 def _span(id, status="possibly"):
     return Span(id=id, status=status, resolution=Resolution.PENDING)

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
-from pipeline.explainer import generate_content, _fallback_content
+
+from pipeline.explainer import _fallback_content, generate_content
 
 SPANS = [{
     "id": "a", "text": "Everyone knows politicians lie",
@@ -8,8 +9,7 @@ SPANS = [{
 }]
 
 def _mock_parsed():
-    from models.span import (ExplainerOutput, ExplainerSpan, ExplainerChallenge,
-                              ExplainerQuestion)
+    from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
     return ExplainerOutput(
         spans=[ExplainerSpan(
             id="a", explanation="Invokes consensus without evidence.",

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,7 +1,12 @@
 from models.span import (
-    ChallengeType, Question, Challenge,
-    SpanResult, AnalysisMeta, AnalyzeResponse,
+    AnalysisMeta,
+    AnalyzeResponse,
+    Challenge,
+    ChallengeType,
+    Question,
+    SpanResult,
 )
+
 
 def test_span_result_serializes():
     span = SpanResult(


### PR DESCRIPTION
## Diagrams

```mermaid
flowchart LR
    A[push / pull_request] --> B[uv venv .venv --python 3.11]
    B --> C[uv pip install requirements + dev]
    C --> D[python -m spacy download en_core_web_sm]
    D --> E[ruff check .<br/>S/ASYNC/B/UP/I/E/F/PL rules]
    E --> F[pyright<br/>standard mode, 0 errors]
    F --> G[pytest -m 'not slow']
    G --> H{green?}
    H -- yes --> I[merge eligible]
    H -- no --> J[fail]
```

## Summary

- **#56 ruff**: adds `backend/pyproject.toml` with `select = [E, F, I, B, UP, S, ASYNC, PL]` so security (`S`), async (`ASYNC`), bugbear (`B`) and modern-syntax (`UP`) issues are actually enforced — not relying on social pressure. A separate commit fixes the 40 pre-existing violations the new rules surfaced (StrEnum migration, import sort, explicit `zip(..., strict=True)`, `Optional[X]` → `X | None`).
- **#57 pyright**: adds `pyright>=1.1.350` to `requirements-dev.txt`, configures `[tool.pyright]` in `standard` mode (strict left as a follow-up — third-party stubs aren't ready), and wires it into CI between `ruff` and `pytest`. Fixes two real type errors in `explainer.py` (Literal narrowing for `ChallengeType`, `None`-check on `msg.parsed`); narrowly ignores stub gaps in `faiss` and `transformers` with one-line justifications.
- **#53 .env.example**: creates `backend/.env.example` documenting `OPENAI_API_KEY` (the only var currently consumed) so contributors can `cp .env.example .env` instead of guessing variable names. Optional vars from related open issues are listed commented-out.
- **#49 deps**: investigated the `transformers<4.51.0` and `spacy<3.8.0` ceilings (introduced in #1 with no rationale). Upgraded locally to `transformers==5.5.4 + spacy==3.8.14`, all CI tests stay green — dropped both ceilings.

## Screenshots

N/A — config/tooling-only PR with no UI surface.

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — green (30 passed, 6 deselected)
- [x] `cd backend && ruff check .` — green ("All checks passed!")
- [x] `cd backend && pyright` — 0 errors, 5 warnings (all `reportMissingTypeStubs` for faiss/transformers/datasets and the documented `_nlp` private import)
- [x] `pip install -r requirements.txt -r requirements-dev.txt` resolves with the lifted version pins (transformers 5.5.4, spacy 3.8.14)
- [x] `touch backend/.env && git status` — `.env` correctly gitignored
- [x] `cp backend/.env.example backend/.env` works
- [ ] `cd frontend && npm test` — N/A, no frontend changes
- [ ] (UI only) Manual smoke via dev servers — N/A, no UI changes

## Plan reference

Closes #56, closes #57, closes #53, closes #49

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
