### PR TITLE
refactor: tighten cascade types and validate at construction

### DIFF
--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class Resolution(StrEnum):
@@ -27,7 +30,15 @@ class DependencyRule(BaseModel):
 class FallacyCollection:
     def __init__(self, spans: list[Span], rules: list[DependencyRule]):
         self.spans: dict[str, Span] = {s.id: s for s in spans}
-        self.rules = rules
+        # Drop rules referencing unknown span IDs so a hallucinated LLM rule
+        # can't KeyError mid-resolve and leave the collection in a partial state.
+        valid_rules: list[DependencyRule] = []
+        for r in rules:
+            if r.source_id not in self.spans or r.dependent_id not in self.spans:
+                logger.warning("dropping cascade rule with unknown id(s): %r", r)
+                continue
+            valid_rules.append(r)
+        self.rules = valid_rules
 
     def resolve(self, span_id: str, outcome: Resolution) -> list[tuple[str, Resolution, str]]:
         self.spans[span_id].resolution = outcome

--- a/backend/models/collection.py
+++ b/backend/models/collection.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import StrEnum
 from typing import Literal
+
+from pydantic import BaseModel
 
 
 class Resolution(StrEnum):
@@ -11,17 +12,15 @@ class Resolution(StrEnum):
     CLEARED   = "CLEARED"
     MOOT      = "MOOT"
 
-@dataclass
-class Span:
+class Span(BaseModel):
     id: str
     status: str
     resolution: Resolution = Resolution.PENDING
 
-@dataclass
-class DependencyRule:
+class DependencyRule(BaseModel):
     source_id: str
     dependent_id: str
-    when: str
+    when: Literal["CONFIRMED", "CLEARED"]
     effect: Literal["moot"]
     reason: str
 

--- a/backend/models/span.py
+++ b/backend/models/span.py
@@ -26,7 +26,7 @@ class Challenge(BaseModel):
 class DependencyRule(BaseModel):
     source_id: str
     dependent_id: str
-    when: str       # "CONFIRMED" | "CLEARED"
+    when: Literal["CONFIRMED", "CLEARED"]
     effect: Literal["moot"]
     reason: str
 

--- a/backend/tests/test_collection.py
+++ b/backend/tests/test_collection.py
@@ -69,3 +69,24 @@ def test_preview_cascade_does_not_mutate():
     )
     col.preview_cascade("a", Resolution.CONFIRMED)
     assert col.spans["b"].resolution == Resolution.PENDING
+
+
+def test_rule_with_unknown_dependent_id_is_filtered(caplog):
+    bad = DependencyRule(source_id="a", dependent_id="ghost",
+                         when="CONFIRMED", effect="moot", reason="x")
+    good = DependencyRule(source_id="a", dependent_id="b",
+                          when="CONFIRMED", effect="moot", reason="real")
+    with caplog.at_level("WARNING", logger="models.collection"):
+        col = FallacyCollection(spans=[_span("a"), _span("b")], rules=[bad, good])
+    assert col.rules == [good]
+    cascades = col.resolve("a", Resolution.CONFIRMED)
+    assert cascades == [("b", Resolution.MOOT, "real")]
+    assert any("dropping cascade rule" in r.message for r in caplog.records)
+
+
+def test_rule_with_unknown_source_id_is_filtered():
+    bad = DependencyRule(source_id="ghost", dependent_id="a",
+                         when="CONFIRMED", effect="moot", reason="x")
+    col = FallacyCollection(spans=[_span("a")], rules=[bad])
+    assert col.rules == []
+    col.resolve("a", Resolution.CONFIRMED)

--- a/backend/tests/test_collection.py
+++ b/backend/tests/test_collection.py
@@ -1,8 +1,38 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
 from models.collection import DependencyRule, FallacyCollection, Resolution, Span
 
 
 def _span(id, status="possibly"):
     return Span(id=id, status=status, resolution=Resolution.PENDING)
+
+
+def test_span_and_dependency_rule_are_pydantic():
+    assert issubclass(Span, BaseModel)
+    assert issubclass(DependencyRule, BaseModel)
+
+
+def test_dependency_rule_rejects_lowercase_when():
+    with pytest.raises(ValidationError):
+        DependencyRule(
+            source_id="a",
+            dependent_id="b",
+            when="confirmed",
+            effect="moot",
+            reason="x",
+        )
+
+
+def test_dependency_rule_rejects_pending_when():
+    with pytest.raises(ValidationError):
+        DependencyRule(
+            source_id="a",
+            dependent_id="b",
+            when="PENDING",
+            effect="moot",
+            reason="x",
+        )
 
 def test_resolve_confirmed_cascades_moot():
     col = FallacyCollection(

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,8 +1,12 @@
+import pytest
+from pydantic import ValidationError
+
 from models.span import (
     AnalysisMeta,
     AnalyzeResponse,
     Challenge,
     ChallengeType,
+    DependencyRule,
     Question,
     SpanResult,
 )
@@ -31,3 +35,23 @@ def test_analyze_response_empty_spans():
         sentence_count=3, argument_span_count=0, fallacy_count=0, processing_ms=42
     ))
     assert resp.spans == []
+
+def test_dependency_rule_rejects_pending_when():
+    with pytest.raises(ValidationError):
+        DependencyRule(
+            source_id="a",
+            dependent_id="b",
+            when="PENDING",
+            effect="moot",
+            reason="x",
+        )
+
+def test_dependency_rule_rejects_lowercase_when():
+    with pytest.raises(ValidationError):
+        DependencyRule(
+            source_id="a",
+            dependent_id="b",
+            when="confirmed",
+            effect="moot",
+            reason="x",
+        )


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant LLM as GPT-4o mini
    participant API as /analyze
    participant Coll as FallacyCollection.__init__
    participant UI as React useFallacyCollection

    Note over LLM,UI: Before — silent corruption
    LLM->>API: rule { when: "PENDING", dependent_id: "ghost" }
    API->>UI: returns rule unchanged (str accepts anything)
    UI->>Coll: construct collection
    Note over Coll: silently never matches CONFIRMED/CLEARED<br/>OR KeyError mid-resolve

    Note over LLM,UI: After — fail fast at the boundary
    LLM->>API: rule { when: "PENDING", dependent_id: "ghost" }
    API-->>LLM: ValidationError on Literal["CONFIRMED","CLEARED"]
    Note over API: malformed rule never reaches the wire
    API->>Coll: spans + rules
    Coll->>Coll: drop rule with unknown dependent_id<br/>(logger.warning)
    Coll-->>UI: only well-formed rules survive
```

```mermaid
classDiagram
    class Resolution {
        <<StrEnum>>
        PENDING
        CONFIRMED
        CLEARED
        MOOT
    }
    class Span {
        <<BaseModel>>
        id: str
        status: str
        resolution: Resolution
    }
    class DependencyRule {
        <<BaseModel>>
        source_id: str
        dependent_id: str
        when: Literal["CONFIRMED","CLEARED"]
        effect: Literal["moot"]
        reason: str
    }
    class FallacyCollection {
        spans: dict[str, Span]
        rules: list[DependencyRule]
        __init__() drops rules with unknown ids
        resolve()
        preview_cascade()
    }
    FallacyCollection o-- Span
    FallacyCollection o-- DependencyRule
    Span --> Resolution
```

## Summary

- **Why Pydantic for cascade types (#54):** `DependencyRule.when` must equal `Resolution.value` exactly or the cascade silently never fires. Dataclass gave us no validation, so a lowercase typo or LLM-hallucinated value was accepted and the bug only surfaced as "cascade didn't happen" with no traceback.
- **Why `Literal["CONFIRMED","CLEARED"]` everywhere (#41):** The wire `DependencyRule` (in `span.py`) had drifted from `ExplainerDependencyRule` (the LLM-facing model that already used the Literal). The bare `str` with a comment was a TODO masquerading as a type — pydantic now enforces the contract at the API boundary.
- **Why filter unknown IDs at construction (#51):** A hallucinated `dependent_id` raised `KeyError` mid-`resolve()`, leaving the source span resolved but the cascade half-applied with no recovery path. The TS mirror silently no-ops on the same input — this aligns Python with that behaviour and logs a warning so the drop is debuggable.

## Screenshots

N/A — backend types only.

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — 37 passed, 6 deselected
- [x] `ruff check .` — All checks passed
- [x] `pyright` — 0 errors, 5 pre-existing warnings (faiss/datasets stubs, private-use)
- [x] New test: `DependencyRule(when="confirmed")` raises `ValidationError` (collection.py)
- [x] New test: `DependencyRule(when="PENDING")` raises `ValidationError` (collection.py and span.py)
- [x] New test: rule with unknown `dependent_id` is filtered, `resolve()` does not raise, warning is logged
- [x] New test: rule with unknown `source_id` is filtered
- [x] All 5 pre-existing collection tests still green (cascade behaviour unchanged for valid inputs)
- [ ] `cd frontend && npm test` — N/A, no frontend changes (mirror tracked by PR 8)

## Plan reference

Closes #41, closes #54, closes #51.

---

Generated with [Claude Code](https://claude.com/claude-code)
