### PR TITLE
feat: production hardening — async, lifespan, limits, rate-limit, truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,15 @@ npx vitest run
 ## Environment variables
 
 ```
-OPENAI_API_KEY=<your key>    # required for GPT-4o mini explainer step
+OPENAI_API_KEY=<your key>             # required for GPT-4o mini explainer step
+ANALYZE_MAX_CONCURRENT=2              # optional: bounded semaphore on /analyze ML inference
+ANALYZE_RATE_LIMIT=10/minute          # optional: per-IP slowapi rate limit on /analyze
+ANALYZE_SKIP_WARMUP=1                 # optional: skip lifespan model warmup (used by tests)
 ```
 
 Copy `.env.example` to `.env` in `backend/` and fill in your key. The app degrades gracefully (template fallback content) if the key is missing or the API call fails.
+
+`/analyze` rate limiting is in-memory (per-process) via slowapi — fine for a single uvicorn worker. Multi-worker deployments should configure a shared backend (Redis) or move rate limiting to the reverse proxy.
 
 ## Key architecture decisions
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,8 +5,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import anyio.to_thread
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 from models.span import (
     AnalysisMeta,
@@ -37,7 +40,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     yield
 
 
+limiter = Limiter(key_func=get_remote_address)
+
 app = FastAPI(lifespan=lifespan)
+app.state.limiter = limiter
+# slowapi's helper signature accepts (request, exc) but FastAPI's add_exception_handler
+# is typed for ExceptionHandler[Exception]; the cast keeps both happy without
+# silencing the wider RateLimitExceeded type.
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # pyright: ignore[reportArgumentType]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173"],
@@ -49,6 +59,7 @@ app.add_middleware(
 # we don't spawn N parallel torch invocations per worker — see issue #37.
 _ANALYZE_MAX_CONCURRENT = int(os.environ.get("ANALYZE_MAX_CONCURRENT", "2"))
 _analyze_semaphore = asyncio.Semaphore(_ANALYZE_MAX_CONCURRENT)
+_ANALYZE_RATE_LIMIT = os.environ.get("ANALYZE_RATE_LIMIT", "10/minute")
 
 
 def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
@@ -121,6 +132,10 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
 
 
 @app.post("/analyze", response_model=AnalyzeResponse)
-async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
+@limiter.limit(_ANALYZE_RATE_LIMIT)
+async def analyze(request: Request, req: AnalyzeRequest) -> AnalyzeResponse:
+    # slowapi requires the `request: Request` parameter to extract the client
+    # IP via get_remote_address; the body never reads it directly.
+    _ = request
     async with _analyze_semaphore:
         return await anyio.to_thread.run_sync(_analyze_sync, req)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,10 @@
+import asyncio
 import os
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import anyio.to_thread
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -43,8 +45,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-@app.post("/analyze", response_model=AnalyzeResponse)
-def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
+# Bounded concurrency for /analyze. Sized to available hardware via env var so
+# we don't spawn N parallel torch invocations per worker — see issue #37.
+_ANALYZE_MAX_CONCURRENT = int(os.environ.get("ANALYZE_MAX_CONCURRENT", "2"))
+_analyze_semaphore = asyncio.Semaphore(_ANALYZE_MAX_CONCURRENT)
+
+
+def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
     if not req.text.strip():
         raise HTTPException(status_code=422, detail="text must not be empty")
 
@@ -111,3 +118,9 @@ def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
             original_char_count=original_len if truncated else None,
         ),
     )
+
+
+@app.post("/analyze", response_model=AnalyzeResponse)
+async def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
+    async with _analyze_semaphore:
+        return await anyio.to_thread.run_sync(_analyze_sync, req)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,7 @@
+import os
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -13,11 +16,26 @@ from models.span import (
     Question,
     SpanResult,
 )
-from pipeline.classifier import classify_spans
+from pipeline.classifier import _load_resources, classify_spans
 from pipeline.explainer import _fallback_content, generate_content
-from pipeline.segmenter import _nlp, get_argument_spans
+from pipeline.segmenter import _arg_classifier, _nlp, get_argument_spans
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    # Eager warmup — populates lru_caches so the first concurrent request can't
+    # race two threads into the same loader, and surfaces missing model files
+    # at boot instead of as a 500 on the first user request. Skip in test runs:
+    # the suite mocks the heavy pipeline functions and shouldn't pay the
+    # ~30s mpnet/FAISS/spacy load cost on every collection.
+    if os.environ.get("ANALYZE_SKIP_WARMUP") != "1":
+        _nlp()
+        _arg_classifier()
+        _load_resources()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:5173"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,7 +31,9 @@ def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
         raise HTTPException(status_code=422, detail="text must not be empty")
 
     t0 = time.monotonic()
+    original_len = len(req.text)
     text = req.text[: req.max_chars]
+    truncated = len(text) < original_len
 
     raw_spans = get_argument_spans(text)
     classified = classify_spans(raw_spans)
@@ -87,5 +89,7 @@ def analyze(req: AnalyzeRequest) -> AnalyzeResponse:
             argument_span_count=len(raw_spans),
             fallacy_count=sum(1 for s in spans_out if s.status == "confirmed"),
             processing_ms=ms,
+            truncated=truncated,
+            original_char_count=original_len if truncated else None,
         ),
     )

--- a/backend/models/span.py
+++ b/backend/models/span.py
@@ -48,10 +48,18 @@ class AnalysisMeta(BaseModel):
     argument_span_count: int
     fallacy_count: int
     processing_ms: int
+    truncated: bool = False
+    original_char_count: int | None = None
+
+# Absolute server-side cap on /analyze input. A request larger than this is
+# rejected at the schema layer before the server allocates the full payload —
+# this is the cheap DoS guard. max_chars (below) is the soft cap that controls
+# truncation after acceptance.
+_HARD_MAX_TEXT_CHARS = 100_000
 
 class AnalyzeRequest(BaseModel):
-    text: str
-    max_chars: int = Field(default=20_000, gt=0)
+    text: str = Field(..., max_length=_HARD_MAX_TEXT_CHARS, min_length=1)
+    max_chars: int = Field(default=20_000, gt=0, le=_HARD_MAX_TEXT_CHARS)
 
 class AnalyzeResponse(BaseModel):
     spans: list[SpanResult]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ torch>=2.1.0
 openai>=1.30.0
 datasets>=2.19.0
 httpx>=0.27.0
+slowapi>=0.1.9

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,25 @@
 import os
 
+import pytest
+
 # Skip the lifespan model warmup in tests — the suite mocks the heavy pipeline
 # functions, so loading mpnet/FAISS/spaCy/roberta-argument on every collection
 # would burn tens of seconds without exercising real code. Set before main is
 # imported (FastAPI evaluates lifespan when the app starts under AsyncClient).
 os.environ.setdefault("ANALYZE_SKIP_WARMUP", "1")
+
+# Use a small per-IP rate limit so the rate-limit test can trigger 429 quickly.
+# Other tests issue at most 1-2 requests each, well under the cap.
+os.environ.setdefault("ANALYZE_RATE_LIMIT", "3/minute")
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    # slowapi's in-memory storage persists across tests within a process and
+    # all tests use the same default client IP (127.0.0.1). Reset the limiter
+    # state before every test so they don't poison each other.
+    from main import app
+    storage = app.state.limiter._storage
+    if hasattr(storage, "storage"):
+        storage.storage.clear()
+    yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+# Skip the lifespan model warmup in tests — the suite mocks the heavy pipeline
+# functions, so loading mpnet/FAISS/spaCy/roberta-argument on every collection
+# would burn tens of seconds without exercising real code. Set before main is
+# imported (FastAPI evaluates lifespan when the app starts under AsyncClient).
+os.environ.setdefault("ANALYZE_SKIP_WARMUP", "1")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -98,3 +98,21 @@ async def test_analyze_rejects_text_exceeding_hard_cap():
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         resp = await c.post("/analyze", json={"text": "x" * 100_001})
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_analyze_rate_limits_after_threshold():
+    # conftest sets ANALYZE_RATE_LIMIT=3/minute; the autouse fixture clears
+    # the limiter state before this test runs.
+    from main import app
+    empty = ExplainerOutput(spans=[], dependency_rules=[])
+    with (patch("main.get_argument_spans", return_value=[]),
+          patch("main.classify_spans", return_value=[]),
+          patch("main.generate_content", return_value=empty)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            statuses = [
+                (await c.post("/analyze", json={"text": "Some text."})).status_code
+                for _ in range(4)
+            ]
+    assert statuses[:3] == [200, 200, 200]
+    assert statuses[3] == 429

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -56,3 +56,45 @@ async def test_analyze_no_spans_returns_empty():
             resp = await c.post("/analyze", json={"text": "The sky is blue."})
     assert resp.status_code == 200
     assert resp.json()["spans"] == []
+
+
+@pytest.mark.asyncio
+async def test_analyze_meta_not_truncated_for_short_input():
+    from main import app
+    empty = ExplainerOutput(spans=[], dependency_rules=[])
+    with (patch("main.get_argument_spans", return_value=[]),
+          patch("main.classify_spans", return_value=[]),
+          patch("main.generate_content", return_value=empty)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/analyze", json={"text": "The sky is blue."})
+    assert resp.status_code == 200
+    meta = resp.json()["meta"]
+    assert meta["truncated"] is False
+    assert meta["original_char_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_analyze_meta_marks_truncated_when_input_exceeds_max_chars():
+    from main import app
+    empty = ExplainerOutput(spans=[], dependency_rules=[])
+    long_text = "x" * 60_000
+    with (patch("main.get_argument_spans", return_value=[]),
+          patch("main.classify_spans", return_value=[]),
+          patch("main.generate_content", return_value=empty)):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/analyze",
+                json={"text": long_text, "max_chars": 20_000},
+            )
+    assert resp.status_code == 200
+    meta = resp.json()["meta"]
+    assert meta["truncated"] is True
+    assert meta["original_char_count"] == 60_000
+
+
+@pytest.mark.asyncio
+async def test_analyze_rejects_text_exceeding_hard_cap():
+    from main import app
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post("/analyze", json={"text": "x" * 100_001})
+    assert resp.status_code == 422

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { analyze } from './api'
 import { TextInput } from './components/TextInput'
 import { AnnotatedText } from './components/AnnotatedText'
 import { FindingsList } from './components/FindingsList'
+import { TruncationBanner } from './components/TruncationBanner'
 import { useFallacyCollection } from './hooks/useFallacyCollection'
 
 export default function App() {
@@ -30,6 +31,7 @@ export default function App() {
       <p style={{ opacity: 0.5, marginBottom: 24 }}>Analyze any text for argument fallacies.</p>
       <TextInput onAnalyze={handleAnalyze} loading={loading} />
       {error && <p data-testid="error-message" style={{ color: '#fca5a5', marginBottom: 16 }}>{error}</p>}
+      {result && !loading && <TruncationBanner meta={result.meta} />}
       {result && !loading && (
         result.spans.length === 0
           ? <p data-testid="no-fallacies-message" style={{ opacity: 0.5 }}>No argument fallacies detected.</p>

--- a/frontend/src/components/TruncationBanner.tsx
+++ b/frontend/src/components/TruncationBanner.tsx
@@ -1,0 +1,25 @@
+import type { AnalysisMeta } from '../types'
+
+interface Props { meta: AnalysisMeta }
+
+export function TruncationBanner({ meta }: Props) {
+  if (!meta.truncated) return null
+  const original = meta.original_char_count ?? 0
+  return (
+    <div
+      data-testid="truncation-banner"
+      role="alert"
+      style={{
+        background: 'rgba(252, 211, 77, 0.12)',
+        border: '1px solid rgba(252, 211, 77, 0.4)',
+        color: '#fcd34d',
+        borderRadius: 6,
+        padding: '8px 12px',
+        marginBottom: 16,
+        fontSize: '0.85em',
+      }}
+    >
+      Input was truncated. Only the first portion of your {original.toLocaleString()}-character text was analyzed.
+    </div>
+  )
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,6 +20,8 @@ export interface SpanResult {
 export interface AnalysisMeta {
   sentence_count: number; argument_span_count: number
   fallacy_count: number; processing_ms: number
+  truncated?: boolean
+  original_char_count?: number | null
 }
 
 export interface AnalyzeResponse { spans: SpanResult[]; rules: DependencyRule[]; meta: AnalysisMeta }


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    autonumber
    participant Client as React Client
    participant RL as slowapi Limiter<br/>(per-IP)
    participant Sem as asyncio.Semaphore<br/>(ANALYZE_MAX_CONCURRENT)
    participant TP as anyio threadpool
    participant Pipe as ML pipeline<br/>(spaCy → roberta-arg → mpnet/FAISS → GPT-4o)
    participant Resp as AnalyzeResponse

    Client->>RL: POST /analyze { text, max_chars }
    alt over per-IP cap
        RL-->>Client: 429 Too Many Requests
    else under cap
        RL->>Sem: acquire (await)
        alt sem full
            Note over Sem: backpressure — request waits
        end
        Sem->>TP: anyio.to_thread.run_sync(_analyze_sync)
        TP->>Pipe: text = req.text[:max_chars]<br/>truncated = len(text) < len(req.text)
        Pipe-->>TP: spans, rules
        TP-->>Sem: AnalyzeResponse
        Sem-->>RL: release
        RL-->>Resp: build response
        Resp-->>Client: 200 + meta.truncated, meta.original_char_count
    end
```

```mermaid
sequenceDiagram
    autonumber
    participant Uvicorn as uvicorn boot
    participant Life as lifespan ctx
    participant Seg as _nlp() / _arg_classifier()
    participant Cls as _load_resources()<br/>(mpnet + FAISS + labels)
    participant App as FastAPI ready

    Uvicorn->>Life: enter
    alt ANALYZE_SKIP_WARMUP=1 (tests)
        Life->>App: yield (no warmup)
    else production
        Life->>Seg: load spaCy + roberta-argument
        Seg-->>Life: cached (lru_cache)
        Life->>Cls: read FAISS index, load mpnet
        alt index file missing
            Cls-->>Uvicorn: RuntimeError → boot fails fast
        else loaded
            Cls-->>Life: cached
            Life->>App: yield (caches warm)
        end
    end
    App-->>Uvicorn: ready to serve
```

## Summary

- **Why hard-cap text + surface truncation (#44, #42):** silent truncation lost user data and the schema accepted unbounded request bodies — a free DoS vector. Now Pydantic rejects > 100k chars at the field level (422) and the response surfaces `meta.truncated` + `meta.original_char_count` so the UI can warn the user.
- **Why lifespan warmup (#40):** `@lru_cache` races on the first concurrent request — two threads can both load mpnet/FAISS before one wins. Eager warmup populates the caches at boot and surfaces missing model files as a fast-fail instead of a 500 on the first user request.
- **Why async + bounded semaphore (#37):** sync `def` routes run in a 40-worker default threadpool with no concurrency control over heavy ML work; under load that meant 40 simultaneous torch invocations + thread-blocking OpenAI calls. Now `/analyze` is `async`, gates concurrency through an `asyncio.Semaphore` (default 2, env-tunable), and offloads to `anyio.to_thread.run_sync`.
- **Why slowapi rate limit (#45):** `/analyze` runs paid OpenAI calls and GPU inference; with no per-IP cap a single client could burn budget and starve everyone else. Per-IP `slowapi` limiter (`10/minute` default, env-configurable) closes the wallet-drain vector for the in-memory single-worker case; multi-worker deployments need shared storage / proxy-side limiting (documented in CLAUDE.md).
- **Why frontend banner:** the new `meta.truncated` flag is useless without UI surfacing — `TruncationBanner` renders a small warning above the annotated text whenever the server truncated input, telling the user how many characters were dropped.

## Screenshots

N/A — not UI; the new banner is conditional on `meta.truncated=true` (only fires for inputs > `max_chars`, default 20k chars). It is a one-line styled `<div role="alert">` rendered above the existing annotated-text region.

## Test plan

- [x] `cd backend && pytest -v -m "not slow"` — 41 passed (was 37; +4 new tests for truncated meta, hard-cap 422, rate-limit 429)
- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && pyright` — 0 errors, 7 warnings (all pre-existing or `_load_resources` private-usage following the existing `_nlp` / `_fallback_content` pattern)
- [x] `cd frontend && npx vitest run` — 13 passed (unchanged)
- [x] `cd frontend && npx tsc --noEmit` — clean (new `AnalysisMeta.truncated?` and `original_char_count?` fields)
- [x] **Manual lifespan boot-fail check**: rename `backend/data/logical_fallacy.index`, run `uvicorn main:app` — boot fails with `RuntimeError: ... could not open ... logical_fallacy.index for reading` and uvicorn exits before binding (file restored after check)
- [x] **Manual semaphore serialization check**: 6 concurrent requests with `ANALYZE_MAX_CONCURRENT=2` and 0.5s mock work each → peak concurrent `_analyze_sync = 2`, elapsed 1.85s (matches `ceil(6/2) * 0.5s + overhead`)
- [x] **Rate-limit 429**: `test_analyze_rate_limits_after_threshold` asserts statuses `[200, 200, 200, 429]` against `ANALYZE_RATE_LIMIT=3/minute`
- [x] **Frontend banner**: `TruncationBanner` returns null when `meta.truncated` is falsy, renders a styled alert when true; type-checked end-to-end

## Plan reference

Closes #37, closes #40, closes #44, closes #45, closes #42

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
