### PR TITLE
perf: pipeline cleanup — single segmentation pass + GPU autoselect

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,7 +23,7 @@ from models.span import (
 )
 from pipeline.classifier import _load_resources, classify_spans
 from pipeline.explainer import _fallback_content, generate_content
-from pipeline.segmenter import _arg_classifier, _nlp, get_argument_spans
+from pipeline.segmenter import get_argument_spans
 
 
 @asynccontextmanager
@@ -34,8 +34,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # the suite mocks the heavy pipeline functions and shouldn't pay the
     # ~30s mpnet/FAISS/spacy load cost on every collection.
     if os.environ.get("ANALYZE_SKIP_WARMUP") != "1":
-        _nlp()
-        _arg_classifier()
+        get_argument_spans("warmup.")
         _load_resources()
     yield
 
@@ -71,7 +70,8 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
     text = req.text[: req.max_chars]
     truncated = len(text) < original_len
 
-    raw_spans = get_argument_spans(text)
+    seg = get_argument_spans(text)
+    raw_spans = seg.spans
     classified = classify_spans(raw_spans)
     for i, span in enumerate(classified):
         span["id"] = f"span_{i}"
@@ -121,7 +121,7 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
         spans=spans_out,
         rules=rules_out,
         meta=AnalysisMeta(
-            sentence_count=len(list(_nlp()(text).sents)),
+            sentence_count=seg.sentence_count,
             argument_span_count=len(raw_spans),
             fallacy_count=sum(1 for s in spans_out if s.status == "confirmed"),
             processing_ms=ms,

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -1,18 +1,24 @@
 import json
+import logging
 import pathlib
 from functools import lru_cache
 
 import faiss
 import numpy as np
+import torch
 from sentence_transformers import SentenceTransformer
 
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 CONFIDENCE_THRESHOLD = 0.82
 
+logger = logging.getLogger(__name__)
+
 
 @lru_cache(maxsize=1)
 def _load_resources():
-    model = SentenceTransformer("all-mpnet-base-v2")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info("sentence-transformers device: %s", device)
+    model = SentenceTransformer("all-mpnet-base-v2", device=device)
     index = faiss.read_index(str(DATA_DIR / "logical_fallacy.index"))
     labels = json.loads((DATA_DIR / "logical_fallacy_labels.json").read_text())
     return model, index, labels

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -1,7 +1,13 @@
 from functools import lru_cache
+from typing import NamedTuple
 
 import spacy
 from transformers import pipeline as hf_pipeline
+
+
+class SegmentationResult(NamedTuple):
+    spans: list[dict]
+    sentence_count: int
 
 
 @lru_cache(maxsize=1)
@@ -16,20 +22,21 @@ def _arg_classifier():
         device=-1,
     )
 
-def get_argument_spans(text: str) -> list[dict]:
+def get_argument_spans(text: str) -> SegmentationResult:
     if not text.strip():
-        return []
+        return SegmentationResult([], 0)
     doc = _nlp()(text)
     sentences = list(doc.sents)
     if not sentences:
-        return []
+        return SegmentationResult([], 0)
     texts = [s.text for s in sentences]
     labels = _arg_classifier()(texts, batch_size=16, truncation=True)
     # chkla/roberta-argument outputs "ARGUMENT" / "NON-ARGUMENT".
     # transformers stubs type the pipeline return as a broad union (incl. None);
     # at runtime it's a list[dict[str, str]] when called with a list of strings.
-    return [
+    spans = [
         {"text": sent.text, "start": sent.start_char, "end": sent.end_char}
-        for sent, label in zip(sentences, labels, strict=True)  # pyright: ignore[reportArgumentType]
+        for sent, label in zip(sentences, labels, strict=True)
         if label["label"] == "ARGUMENT"
     ]
+    return SegmentationResult(spans, len(sentences))

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -1,8 +1,12 @@
+import logging
 from functools import lru_cache
 from typing import NamedTuple
 
 import spacy
+import torch
 from transformers import pipeline as hf_pipeline
+
+logger = logging.getLogger(__name__)
 
 
 class SegmentationResult(NamedTuple):
@@ -16,10 +20,12 @@ def _nlp():
 
 @lru_cache(maxsize=1)
 def _arg_classifier():
+    device = 0 if torch.cuda.is_available() else -1
+    logger.info("roberta-argument device: %s", "cuda:0" if device == 0 else "cpu")
     return hf_pipeline(
         "text-classification",
         model="chkla/roberta-argument",
-        device=-1,
+        device=device,
     )
 
 def get_argument_spans(text: str) -> SegmentationResult:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
+from pipeline.segmenter import SegmentationResult
 
 
 def _mock_explainer_output():
@@ -22,7 +23,11 @@ def _mock_explainer_output():
         dependency_rules=[],
     )
 
-MOCK_SEGMENTS = [{"text": "All scientists lie.", "start": 0, "end": 18}]
+MOCK_SEGMENTS = SegmentationResult(
+    spans=[{"text": "All scientists lie.", "start": 0, "end": 18}],
+    sentence_count=1,
+)
+EMPTY_SEGMENTS = SegmentationResult(spans=[], sentence_count=1)
 MOCK_CLASSIFIED = [{"text": "All scientists lie.", "start": 0, "end": 18,
                     "fallacy_type": "Faulty Generalization", "confidence": 0.91,
                     "status": "confirmed"}]
@@ -49,7 +54,7 @@ async def test_analyze_empty_text_returns_422():
 async def test_analyze_no_spans_returns_empty():
     from main import app
     empty = ExplainerOutput(spans=[], dependency_rules=[])
-    with (patch("main.get_argument_spans", return_value=[]),
+    with (patch("main.get_argument_spans", return_value=EMPTY_SEGMENTS),
           patch("main.classify_spans", return_value=[]),
           patch("main.generate_content", return_value=empty)):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -62,7 +67,7 @@ async def test_analyze_no_spans_returns_empty():
 async def test_analyze_meta_not_truncated_for_short_input():
     from main import app
     empty = ExplainerOutput(spans=[], dependency_rules=[])
-    with (patch("main.get_argument_spans", return_value=[]),
+    with (patch("main.get_argument_spans", return_value=EMPTY_SEGMENTS),
           patch("main.classify_spans", return_value=[]),
           patch("main.generate_content", return_value=empty)):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -78,7 +83,7 @@ async def test_analyze_meta_marks_truncated_when_input_exceeds_max_chars():
     from main import app
     empty = ExplainerOutput(spans=[], dependency_rules=[])
     long_text = "x" * 60_000
-    with (patch("main.get_argument_spans", return_value=[]),
+    with (patch("main.get_argument_spans", return_value=EMPTY_SEGMENTS),
           patch("main.classify_spans", return_value=[]),
           patch("main.generate_content", return_value=empty)):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -106,7 +111,7 @@ async def test_analyze_rate_limits_after_threshold():
     # the limiter state before this test runs.
     from main import app
     empty = ExplainerOutput(spans=[], dependency_rules=[])
-    with (patch("main.get_argument_spans", return_value=[]),
+    with (patch("main.get_argument_spans", return_value=EMPTY_SEGMENTS),
           patch("main.classify_spans", return_value=[]),
           patch("main.generate_content", return_value=empty)):
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:

--- a/backend/tests/test_segmenter.py
+++ b/backend/tests/test_segmenter.py
@@ -2,22 +2,31 @@ import pytest
 
 pytestmark = pytest.mark.slow
 
-from pipeline.segmenter import get_argument_spans  # noqa: E402
+from pipeline.segmenter import SegmentationResult, get_argument_spans  # noqa: E402
 
 ARGUMENTATIVE = "Taxes are theft and the government has no right to take your money."
 NON_ARG = "The weather in Paris is often mild in spring."
 
-def test_returns_list():
-    assert isinstance(get_argument_spans(ARGUMENTATIVE), list)
+def test_returns_segmentation_result():
+    result = get_argument_spans(ARGUMENTATIVE)
+    assert isinstance(result, SegmentationResult)
+    assert isinstance(result.spans, list)
+    assert isinstance(result.sentence_count, int)
 
 def test_argumentative_sentence_included():
-    spans = get_argument_spans(ARGUMENTATIVE)
-    assert any(ARGUMENTATIVE[:20] in s["text"] for s in spans)
+    result = get_argument_spans(ARGUMENTATIVE)
+    assert any(ARGUMENTATIVE[:20] in s["text"] for s in result.spans)
 
 def test_span_has_required_keys():
-    spans = get_argument_spans(ARGUMENTATIVE)
-    assert len(spans) > 0
-    assert {"text", "start", "end"} <= spans[0].keys()
+    result = get_argument_spans(ARGUMENTATIVE)
+    assert len(result.spans) > 0
+    assert {"text", "start", "end"} <= result.spans[0].keys()
 
 def test_empty_text_returns_empty():
-    assert get_argument_spans("") == []
+    result = get_argument_spans("")
+    assert result.spans == []
+    assert result.sentence_count == 0
+
+def test_sentence_count_matches_segmenter_pass():
+    result = get_argument_spans("Sentence one. Sentence two. Sentence three.")
+    assert result.sentence_count == 3


### PR DESCRIPTION
## Diagrams

```mermaid
sequenceDiagram
    participant Main as main.py
    participant Seg as segmenter.get_argument_spans

    rect rgb(255, 235, 235)
        Note over Main,Seg: BEFORE — double spaCy pass + private import
        Main->>Seg: get_argument_spans(text)
        Seg-->>Main: list[dict]   (sentence_count discarded)
        Main->>Seg: _nlp()(text).sents   (private import, recompute)
        Seg-->>Main: doc.sents
        Note over Main: meta.sentence_count = len(list(_nlp()(text).sents))
    end

    rect rgb(235, 255, 235)
        Note over Main,Seg: AFTER — single pass, public surface only
        Main->>Seg: get_argument_spans(text)
        Seg-->>Main: SegmentationResult(spans, sentence_count)
        Note over Main: meta.sentence_count = seg.sentence_count
    end
```

```mermaid
flowchart LR
    A[_arg_classifier / _load_resources] --> B{torch.cuda.is_available?}
    B -- yes --> C[device = cuda 0 / 'cuda']
    B -- no --> D[device = -1 / 'cpu']
    C --> E[hf_pipeline / SentenceTransformer]
    D --> E
```

## Summary

- **#46 + #50 (combined)** — single segmentation pass eliminates redundant spaCy invocation and removes private cross-module import. `get_argument_spans` now returns a `SegmentationResult` NamedTuple (`spans` + `sentence_count`); `main.py` reads both fields from the same call instead of re-running spaCy on the full text and reaching across the module boundary for `_nlp`.
- **#43** — auto-detect CUDA device for both `roberta-argument` (HF pipeline) and `all-mpnet-base-v2` (SentenceTransformer). On CPU-only hosts behavior is unchanged; on GPU hosts both models now run on `cuda:0` instead of being silently capped at CPU latency. Selected device is logged at first load.
- **Bonus cleanup** — dropped a stale `# pyright: ignore[reportArgumentType]` on the `zip(sentences, labels, strict=True)` line in `segmenter.py`. Verified pyright stays clean without it.

## Screenshots

N/A — backend-only change.

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — green (41 passed)
- [x] `cd backend && source .venv/bin/activate && pytest -v -m "slow" tests/test_segmenter.py` — green (5 passed, including new `test_sentence_count_matches_segmenter_pass`)
- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && pyright` — 0 errors, 5 warnings (all pre-existing — unrelated `_load_resources`/`_fallback_content`/faiss stubs)
- [x] `main.py` no longer imports any underscore-prefixed name from `pipeline.segmenter`
- [x] `meta.sentence_count` semantics unchanged (same value for the same input)
- [x] GPU autoselect verified on CPU-only host: `python -c "import torch; print(torch.cuda.is_available())"` → `False`, tests still pass

Closes #46, closes #50, closes #43

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
