### PR TITLE
chore: pin ML model revisions and add FAISS index metadata sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,12 @@ source .venv/bin/activate
 python data/build_index.py
 ```
 
-Outputs `backend/data/logical_fallacy.index` and `backend/data/logical_fallacy_labels.json`. Commit both.
+Outputs three files in `backend/data/`:
+- `logical_fallacy.index` — the FAISS vector store
+- `logical_fallacy_labels.json` — parallel label list
+- `logical_fallacy.index.meta.json` — sidecar with embedder name/version/SHA + dim + count
+
+Commit all three. The classifier reads the sidecar at startup and refuses to load if `embedder_model` doesn't match, catching the silent-degradation case where the index was built with a different mpnet checkpoint than the loader instantiates.
 
 ## Code conventions
 

--- a/backend/data/build_index.py
+++ b/backend/data/build_index.py
@@ -3,8 +3,11 @@ import pathlib
 
 import faiss
 import numpy as np
+import sentence_transformers
 from datasets import load_dataset
 from sentence_transformers import SentenceTransformer
+
+from pipeline.classifier import EMBEDDER_MODEL, MPNET_REVISION
 
 DATA_DIR = pathlib.Path(__file__).parent
 
@@ -33,7 +36,7 @@ def build():
         labels = [str(lbl) for lbl in raw_labels]
 
     print(f"Encoding {len(texts)} examples with text_col={text_col!r}, label_col={label_col!r}...")
-    model = SentenceTransformer("all-mpnet-base-v2")
+    model = SentenceTransformer(EMBEDDER_MODEL, revision=MPNET_REVISION)
     embeddings = model.encode(
         texts,
         show_progress_bar=True,
@@ -49,7 +52,21 @@ def build():
 
     faiss.write_index(index, str(DATA_DIR / "logical_fallacy.index"))
     (DATA_DIR / "logical_fallacy_labels.json").write_text(json.dumps(labels))
+    # Sidecar lets the loader catch silent embedder/index drift — a regenerated
+    # index with a different mpnet checkpoint still has dim 768, so without
+    # this metadata FAISS would happily return degraded nearest neighbors.
+    meta = {
+        "embedder_model": EMBEDDER_MODEL,
+        "embedder_library_version": sentence_transformers.__version__,
+        "embedder_revision": MPNET_REVISION,
+        "embedding_dim": int(embeddings.shape[1]),
+        "vector_count": int(index.ntotal),
+    }
+    (DATA_DIR / "logical_fallacy.index.meta.json").write_text(
+        json.dumps(meta, indent=2) + "\n"
+    )
     print(f"Done. {index.ntotal} vectors. Labels sample: {labels[:3]}")
+    print(f"Wrote sidecar metadata: {meta}")
 
 
 if __name__ == "__main__":

--- a/backend/data/logical_fallacy.index.meta.json
+++ b/backend/data/logical_fallacy.index.meta.json
@@ -1,0 +1,7 @@
+{
+  "embedder_model": "all-mpnet-base-v2",
+  "embedder_library_version": "5.4.1",
+  "embedder_revision": "e8c3b32edf5434bc2275fc9bab85f82640a19130",
+  "embedding_dim": 768,
+  "vector_count": 2680
+}

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import pathlib
+import warnings
 from functools import lru_cache
 
 import faiss
@@ -25,8 +26,34 @@ MPNET_REVISION = "e8c3b32edf5434bc2275fc9bab85f82640a19130"
 logger = logging.getLogger(__name__)
 
 
+def _verify_index_metadata() -> None:
+    # Sidecar is written by data/build_index.py. Asserting embedder_model
+    # match catches the silent failure mode where the index was built with a
+    # different sentence-transformer than the loader is about to instantiate
+    # — dimensions would still match, FAISS would return nearest neighbors,
+    # and classifications would quietly degrade with no error.
+    meta_path = DATA_DIR / "logical_fallacy.index.meta.json"
+    if not meta_path.exists():
+        warnings.warn(
+            "FAISS index has no .meta.json sidecar; cannot verify embedder "
+            "compatibility. Rebuild with `python data/build_index.py` to "
+            "enable this check.",
+            stacklevel=3,
+        )
+        return
+    meta = json.loads(meta_path.read_text())
+    indexed_embedder = meta.get("embedder_model")
+    if indexed_embedder != EMBEDDER_MODEL:
+        raise RuntimeError(
+            f"FAISS index was built with embedder {indexed_embedder!r} but "
+            f"classifier loads {EMBEDDER_MODEL!r}. Rebuild the index: "
+            f"python data/build_index.py"
+        )
+
+
 @lru_cache(maxsize=1)
 def _load_resources():
+    _verify_index_metadata()
     device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("sentence-transformers device: %s", device)
     model = SentenceTransformer(EMBEDDER_MODEL, device=device, revision=MPNET_REVISION)

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -10,6 +10,17 @@ from sentence_transformers import SentenceTransformer
 
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 CONFIDENCE_THRESHOLD = 0.82
+EMBEDDER_MODEL = "all-mpnet-base-v2"
+
+# Pin the HuggingFace embedder to a specific commit SHA. The FAISS index stores
+# vectors produced by this exact checkpoint — if upstream republishes weights
+# under the same name, dimension would still match but query embeddings would
+# drift apart from the indexed ones, silently degrading classification.
+#
+# To upgrade: bump MPNET_REVISION, rebuild the FAISS index
+# (`python data/build_index.py` writes a new sidecar with the new revision),
+# commit the regenerated index + labels + sidecar, and re-run the tests.
+MPNET_REVISION = "e8c3b32edf5434bc2275fc9bab85f82640a19130"
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +29,7 @@ logger = logging.getLogger(__name__)
 def _load_resources():
     device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("sentence-transformers device: %s", device)
-    model = SentenceTransformer("all-mpnet-base-v2", device=device)
+    model = SentenceTransformer(EMBEDDER_MODEL, device=device, revision=MPNET_REVISION)
     index = faiss.read_index(str(DATA_DIR / "logical_fallacy.index"))
     labels = json.loads((DATA_DIR / "logical_fallacy_labels.json").read_text())
     return model, index, labels

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -8,6 +8,17 @@ from transformers import pipeline as hf_pipeline
 
 logger = logging.getLogger(__name__)
 
+# Pin the HuggingFace model to a specific commit SHA. Without this we'd track
+# upstream HEAD on each cache miss, and a republish that swaps the id2label map
+# (e.g. to LABEL_0 / LABEL_1) would silently make every sentence "not an
+# argument" with no error. See `id2label` check below.
+#
+# To upgrade: bump ROBERTA_ARGUMENT_REVISION to a newer commit SHA from
+# https://huggingface.co/chkla/roberta-argument/commits/main, re-run the test
+# suite, smoke-test segmentation on a handful of inputs, and verify the model's
+# config.json at the new SHA still has id2label = {0: "NON-ARGUMENT", 1: "ARGUMENT"}.
+ROBERTA_ARGUMENT_REVISION = "7c0e6b88c91828ba07dfc473d2d11628e3b734fc"
+
 
 class SegmentationResult(NamedTuple):
     spans: list[dict]
@@ -25,6 +36,7 @@ def _arg_classifier():
     return hf_pipeline(
         "text-classification",
         model="chkla/roberta-argument",
+        revision=ROBERTA_ARGUMENT_REVISION,
         device=device,
     )
 

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from pipeline.classifier import classify_spans
@@ -48,3 +50,85 @@ def test_threshold_determines_status(monkeypatch):
     monkeypatch.setattr(classifier, "_load_resources", lambda: (fake_model, fake_index2, fake_labels))
     result2 = classifier.classify_spans([{"text": "x", "start": 0, "end": 1}])
     assert result2[0]["status"] == "possibly"
+
+
+# Helper for sidecar tests: stub out the heavy SentenceTransformer/faiss loads
+# so we exercise only the metadata read+verify path. We seed _SENTINEL_SLOT with
+# a callable that returns a fake (model, index, labels) triple.
+def _stub_heavy_loads(monkeypatch, classifier_mod):
+    import types
+
+    fake_model = types.SimpleNamespace(encode=lambda *a, **k: None)
+    fake_index = types.SimpleNamespace(search=lambda *a, **k: None)
+    fake_labels = ["x"]
+
+    def fake_st(*args, **kwargs):
+        return fake_model
+
+    def fake_read_index(_path):
+        return fake_index
+
+    monkeypatch.setattr(classifier_mod, "SentenceTransformer", fake_st)
+    monkeypatch.setattr(classifier_mod.faiss, "read_index", fake_read_index)
+    return fake_model, fake_index, fake_labels
+
+
+def test_load_resources_warns_when_sidecar_missing(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    # NOTE: no sidecar file written
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier)
+
+    with pytest.warns(UserWarning, match="meta.json"):
+        classifier._load_resources()
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_raises_on_embedder_mismatch(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": "some-other-embedder",
+        "embedder_library_version": "0.0.0",
+        "embedding_dim": 768,
+        "vector_count": 1,
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier)
+
+    with pytest.raises(RuntimeError, match="some-other-embedder"):
+        classifier._load_resources()
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_accepts_matching_sidecar(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": classifier.EMBEDDER_MODEL,
+        "embedder_library_version": "5.4.1",
+        "embedding_dim": 768,
+        "vector_count": 1,
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier)
+
+    model, index, labels = classifier._load_resources()
+    assert labels == ["x"]
+    classifier._load_resources.cache_clear()

--- a/backend/tests/test_segmenter.py
+++ b/backend/tests/test_segmenter.py
@@ -1,32 +1,67 @@
 import pytest
 
-pytestmark = pytest.mark.slow
+from pipeline.segmenter import (
+    ROBERTA_ARGUMENT_REVISION,
+    SegmentationResult,
+    get_argument_spans,
+)
 
-from pipeline.segmenter import SegmentationResult, get_argument_spans  # noqa: E402
+
+def test_roberta_argument_revision_is_pinned():
+    # 40-char hex sha guarantees we never accidentally fall back to "main"
+    # (which would make the segmenter silently track upstream HEAD).
+    assert isinstance(ROBERTA_ARGUMENT_REVISION, str)
+    assert len(ROBERTA_ARGUMENT_REVISION) == 40
+    assert all(c in "0123456789abcdef" for c in ROBERTA_ARGUMENT_REVISION)
+
+
+def test_arg_classifier_passes_revision_to_hf_pipeline(monkeypatch):
+    captured = {}
+
+    def fake_pipeline(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return lambda *a, **k: []
+
+    from pipeline import segmenter
+
+    segmenter._arg_classifier.cache_clear()
+    monkeypatch.setattr(segmenter, "hf_pipeline", fake_pipeline)
+    segmenter._arg_classifier()
+    segmenter._arg_classifier.cache_clear()
+
+    assert captured["kwargs"].get("revision") == ROBERTA_ARGUMENT_REVISION
+    assert captured["kwargs"].get("model") == "chkla/roberta-argument"
+
 
 ARGUMENTATIVE = "Taxes are theft and the government has no right to take your money."
 NON_ARG = "The weather in Paris is often mild in spring."
 
+
+@pytest.mark.slow
 def test_returns_segmentation_result():
     result = get_argument_spans(ARGUMENTATIVE)
     assert isinstance(result, SegmentationResult)
     assert isinstance(result.spans, list)
     assert isinstance(result.sentence_count, int)
 
+@pytest.mark.slow
 def test_argumentative_sentence_included():
     result = get_argument_spans(ARGUMENTATIVE)
     assert any(ARGUMENTATIVE[:20] in s["text"] for s in result.spans)
 
+@pytest.mark.slow
 def test_span_has_required_keys():
     result = get_argument_spans(ARGUMENTATIVE)
     assert len(result.spans) > 0
     assert {"text", "start", "end"} <= result.spans[0].keys()
 
+@pytest.mark.slow
 def test_empty_text_returns_empty():
     result = get_argument_spans("")
     assert result.spans == []
     assert result.sentence_count == 0
 
+@pytest.mark.slow
 def test_sentence_count_matches_segmenter_pass():
     result = get_argument_spans("Sentence one. Sentence two. Sentence three.")
     assert result.sentence_count == 3


### PR DESCRIPTION
## Diagrams

### Index load-time verification

```mermaid
flowchart TD
    A[_load_resources called] --> B{sidecar<br/>logical_fallacy.index.meta.json<br/>exists?}
    B -- no --> W[warnings.warn<br/>UserWarning: cannot verify<br/>embedder compatibility]
    W --> L[load SentenceTransformer<br/>+ FAISS index + labels]
    B -- yes --> C{embedder_model<br/>matches EMBEDDER_MODEL<br/>?}
    C -- no --> X[raise RuntimeError:<br/>rebuild the index]
    C -- yes --> L
    L --> R[return model, index, labels]
```

### Model SHA pinning

```mermaid
flowchart LR
    HF[HuggingFace Hub<br/>chkla/roberta-argument<br/>+ all-mpnet-base-v2] -. unpinned: tracks HEAD .-> Old[old behavior:<br/>silent drift on republish]
    HF -- revision SHA --> New[pinned: load fails loudly<br/>if SHA goes missing,<br/>otherwise reproducible]
```

## Summary

- **Prevents silent segmenter failure (#58)**: pin `chkla/roberta-argument` and `all-mpnet-base-v2` to specific commit SHAs so an upstream republish that swaps `id2label` (e.g. to `LABEL_0`/`LABEL_1`) can't quietly turn every sentence into "not an argument" with no error
- **Prevents silent classifier degradation (#52)**: stamp the FAISS index with an `embedder_model` + version + revision sidecar so an embedder/index mismatch (same dim, different weights) raises `RuntimeError` at load time instead of silently returning worse nearest neighbors

## Screenshots

N/A — backend-only change.

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — 50 passed, 7 deselected
- [x] `ruff check .` — clean
- [x] `pyright` — 0 errors (5 pre-existing warnings on missing stubs / private-usage in main.py)
- [x] New tests:
  - `test_roberta_argument_revision_is_pinned` — asserts SHA constant exists and is 40 hex chars
  - `test_arg_classifier_passes_revision_to_hf_pipeline` — asserts `revision=` is forwarded
  - `test_load_resources_warns_when_sidecar_missing` — `pytest.warns(UserWarning)`
  - `test_load_resources_raises_on_embedder_mismatch` — `pytest.raises(RuntimeError)`
  - `test_load_resources_accepts_matching_sidecar` — happy path
- [x] Slow smoke: `tests/test_segmenter.py::test_argumentative_sentence_included` passes — the pinned `chkla/roberta-argument` SHA still classifies "Taxes are theft..." as ARGUMENT, confirming `id2label` at this revision is `{0: NON-ARGUMENT, 1: ARGUMENT}`
- [x] Sidecar generated for the existing committed index (no rebuild — would change vectors): `vector_count=2680`, `embedding_dim=768`, matches `len(labels)==2680`
- [x] CLAUDE.md updated to mention the sidecar in the "Build the logical-fallacy index" section

### Pinned revisions

| Model | SHA |
| --- | --- |
| `chkla/roberta-argument` | `7c0e6b88c91828ba07dfc473d2d11628e3b734fc` |
| `sentence-transformers/all-mpnet-base-v2` | `e8c3b32edf5434bc2275fc9bab85f82640a19130` |

## Plan reference

Closes #58, closes #52.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
