### PR TITLE
refactor: typed pipeline — RawSpan and ClassifiedSpan replace dict[str, Any]

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -72,16 +72,20 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
 
     seg = get_argument_spans(text)
     raw_spans = seg.spans
-    classified = classify_spans(raw_spans)
-    for i, span in enumerate(classified):
-        span["id"] = f"span_{i}"
+    classified = [
+        span.model_copy(update={"id": f"span_{i}"})
+        for i, span in enumerate(classify_spans(raw_spans))
+    ]
 
     explainer_out = generate_content(classified, text)
     content_by_id = {s.id: s for s in explainer_out.spans}
 
     spans_out: list[SpanResult] = []
     for span in classified:
-        sid = span["id"]
+        # main.py stamps an id onto every classified span above; assert as a
+        # precondition so a future change that drops the stamp loop fails loud.
+        assert span.id is not None
+        sid = span.id
         c = content_by_id.get(sid)
         model_generated = c is not None
         if c is None:
@@ -89,11 +93,11 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
         ch = c.challenge
         spans_out.append(SpanResult(
             id=sid,
-            text=span["text"],
-            start=span["start"],
-            end=span["end"],
-            status=span["status"],
-            fallacy_type=span["fallacy_type"],
+            text=span.text,
+            start=span.start,
+            end=span.end,
+            status=span.status,
+            fallacy_type=span.fallacy_type,
             explanation=c.explanation,
             challenge=Challenge(
                 type=ChallengeType(ch.type),

--- a/backend/models/span.py
+++ b/backend/models/span.py
@@ -14,6 +14,23 @@ class ChallengeType(StrEnum):
     NON_SEQUITUR         = "non_sequitur"
     PREMISE_CHECK        = "premise_check"
 
+# --- Internal pipeline models (not on the wire) ---
+
+class RawSpan(BaseModel):
+    """Output of the segmenter — sentence text with character offsets."""
+    text: str
+    start: int
+    end: int
+
+class ClassifiedSpan(RawSpan):
+    """Output of the classifier — a RawSpan plus its assigned fallacy_type,
+    confidence score, and confirmation status. `id` is set by main.py after
+    classification, before passing to the explainer."""
+    id: str | None = None
+    fallacy_type: str
+    confidence: float
+    status: Literal["confirmed", "possibly"]
+
 class Question(BaseModel):
     text: str
     yes_label: str

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -9,6 +9,8 @@ import numpy as np
 import torch
 from sentence_transformers import SentenceTransformer
 
+from models.span import ClassifiedSpan, RawSpan
+
 DATA_DIR = pathlib.Path(__file__).parent.parent / "data"
 CONFIDENCE_THRESHOLD = 0.82
 EMBEDDER_MODEL = "all-mpnet-base-v2"
@@ -62,22 +64,22 @@ def _load_resources():
     return model, index, labels
 
 
-def classify_spans(spans: list[dict]) -> list[dict]:
+def classify_spans(spans: list[RawSpan]) -> list[ClassifiedSpan]:
     if not spans:
         return []
     model, index, labels = _load_resources()
     embeddings = model.encode(
-        [s["text"] for s in spans], batch_size=32, normalize_embeddings=True
+        [s.text for s in spans], batch_size=32, normalize_embeddings=True
     )
     embeddings = np.array(embeddings, dtype="float32")
     distances, indices = index.search(embeddings, k=1)
-    result = []
+    result: list[ClassifiedSpan] = []
     for span, dist, idx in zip(spans, distances, indices, strict=True):
         confidence = float(dist[0])
-        result.append({
-            **span,
-            "fallacy_type": labels[int(idx[0])],
-            "confidence": confidence,
-            "status": "confirmed" if confidence >= CONFIDENCE_THRESHOLD else "possibly",
-        })
+        result.append(ClassifiedSpan(
+            **span.model_dump(),
+            fallacy_type=labels[int(idx[0])],
+            confidence=confidence,
+            status="confirmed" if confidence >= CONFIDENCE_THRESHOLD else "possibly",
+        ))
     return result

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -5,7 +5,13 @@ from typing import Literal, cast
 
 from openai import OpenAI
 
-from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
+from models.span import (
+    ClassifiedSpan,
+    ExplainerChallenge,
+    ExplainerOutput,
+    ExplainerQuestion,
+    ExplainerSpan,
+)
 from pipeline.challenge_types import challenge_type_for
 
 ChallengeTypeLiteral = Literal[
@@ -61,16 +67,20 @@ _TEMPLATE_QUESTIONS = {
                              "Well established → not a fallacy"),
 }
 
-def _fallback_content(spans: list[dict]) -> ExplainerOutput:
+def _fallback_content(spans: list[ClassifiedSpan]) -> ExplainerOutput:
     result_spans = []
     for span in spans:
         # challenge_type_for returns one of the keys of _TEMPLATE_QUESTIONS,
         # which is exactly ChallengeTypeLiteral; cast to the narrower type.
-        ct = cast(ChallengeTypeLiteral, challenge_type_for(span["fallacy_type"]))
+        ct = cast(ChallengeTypeLiteral, challenge_type_for(span.fallacy_type))
         q_text, yes_lbl, no_lbl = _TEMPLATE_QUESTIONS[ct]
+        # main.py stamps an id onto every span before this is reached; assert
+        # it as a precondition so a bug upstream surfaces here, not as a silent
+        # `id=None` propagating into the wire response.
+        assert span.id is not None, "span.id must be set before _fallback_content"
         result_spans.append(ExplainerSpan(
-            id=span["id"],
-            explanation=f"Possibly a {span['fallacy_type']}.",
+            id=span.id,
+            explanation=f"Possibly a {span.fallacy_type}.",
             challenge=ExplainerChallenge(
                 type=ct,
                 question=ExplainerQuestion(text=q_text, yes_label=yes_lbl, no_label=no_lbl),
@@ -81,7 +91,7 @@ def _fallback_content(spans: list[dict]) -> ExplainerOutput:
     return ExplainerOutput(spans=result_spans, dependency_rules=[])
 
 def generate_content(
-    spans: list[dict],
+    spans: list[ClassifiedSpan],
     full_text: str,
     client: OpenAI | None = None,
 ) -> ExplainerOutput:
@@ -96,7 +106,10 @@ def generate_content(
             return _fallback_content(spans)
         client = OpenAI(api_key=api_key, timeout=30.0, max_retries=0)
 
-    payload = json.dumps({"full_text": full_text, "spans": spans}, ensure_ascii=False)
+    payload = json.dumps(
+        {"full_text": full_text, "spans": [s.model_dump() for s in spans]},
+        ensure_ascii=False,
+    )
 
     if len(payload) > _MAX_PAYLOAD_CHARS:
         logger.warning(

--- a/backend/pipeline/segmenter.py
+++ b/backend/pipeline/segmenter.py
@@ -6,6 +6,8 @@ import spacy
 import torch
 from transformers import pipeline as hf_pipeline
 
+from models.span import RawSpan
+
 logger = logging.getLogger(__name__)
 
 # Pin the HuggingFace model to a specific commit SHA. Without this we'd track
@@ -21,7 +23,7 @@ ROBERTA_ARGUMENT_REVISION = "7c0e6b88c91828ba07dfc473d2d11628e3b734fc"
 
 
 class SegmentationResult(NamedTuple):
-    spans: list[dict]
+    spans: list[RawSpan]
     sentence_count: int
 
 
@@ -53,7 +55,7 @@ def get_argument_spans(text: str) -> SegmentationResult:
     # transformers stubs type the pipeline return as a broad union (incl. None);
     # at runtime it's a list[dict[str, str]] when called with a list of strings.
     spans = [
-        {"text": sent.text, "start": sent.start_char, "end": sent.end_char}
+        RawSpan(text=sent.text, start=sent.start_char, end=sent.end_char)
         for sent, label in zip(sentences, labels, strict=True)
         if label["label"] == "ARGUMENT"
     ]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from models.span import (
+    ClassifiedSpan,
     ExplainerChallenge,
     ExplainerOutput,
     ExplainerQuestion,
@@ -34,9 +35,11 @@ MOCK_SEGMENTS = SegmentationResult(
     sentence_count=1,
 )
 EMPTY_SEGMENTS = SegmentationResult(spans=[], sentence_count=1)
-MOCK_CLASSIFIED = [{"text": "All scientists lie.", "start": 0, "end": 18,
-                    "fallacy_type": "Faulty Generalization", "confidence": 0.91,
-                    "status": "confirmed"}]
+MOCK_CLASSIFIED = [ClassifiedSpan(
+    text="All scientists lie.", start=0, end=18,
+    fallacy_type="Faulty Generalization", confidence=0.91,
+    status="confirmed",
+)]
 
 @pytest.mark.asyncio
 async def test_analyze_returns_spans():

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3,7 +3,13 @@ from unittest.mock import patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
+from models.span import (
+    ExplainerChallenge,
+    ExplainerOutput,
+    ExplainerQuestion,
+    ExplainerSpan,
+    RawSpan,
+)
 from pipeline.segmenter import SegmentationResult
 
 
@@ -24,7 +30,7 @@ def _mock_explainer_output():
     )
 
 MOCK_SEGMENTS = SegmentationResult(
-    spans=[{"text": "All scientists lie.", "start": 0, "end": 18}],
+    spans=[RawSpan(text="All scientists lie.", start=0, end=18)],
     sentence_count=1,
 )
 EMPTY_SEGMENTS = SegmentationResult(spans=[], sentence_count=1)

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -2,25 +2,27 @@ import json
 
 import pytest
 
+from models.span import ClassifiedSpan, RawSpan
 from pipeline.classifier import classify_spans
 
 
 @pytest.mark.slow
 def test_returns_status_and_fallacy_type():
-    spans = [{"text": "Everyone knows vaccines cause autism.", "start": 0, "end": 36}]
+    spans = [RawSpan(text="Everyone knows vaccines cause autism.", start=0, end=36)]
     result = classify_spans(spans)
     assert len(result) == 1
-    assert result[0]["status"] in ("confirmed", "possibly")
-    assert "fallacy_type" in result[0]
-    assert "confidence" in result[0]
+    assert isinstance(result[0], ClassifiedSpan)
+    assert result[0].status in ("confirmed", "possibly")
+    assert result[0].fallacy_type
+    assert isinstance(result[0].confidence, float)
 
 
 @pytest.mark.slow
 def test_preserves_original_keys():
-    spans = [{"text": "All politicians lie.", "start": 0, "end": 20}]
+    spans = [RawSpan(text="All politicians lie.", start=0, end=20)]
     result = classify_spans(spans)
-    assert result[0]["start"] == 0
-    assert result[0]["end"] == 20
+    assert result[0].start == 0
+    assert result[0].end == 20
 
 
 def test_threshold_determines_status(monkeypatch):
@@ -39,17 +41,17 @@ def test_threshold_determines_status(monkeypatch):
     from pipeline import classifier
     monkeypatch.setattr(classifier, "_load_resources", lambda: (fake_model, fake_index, fake_labels))
 
-    result = classifier.classify_spans([{"text": "x", "start": 0, "end": 1}])
-    assert result[0]["status"] == "confirmed"
-    assert result[0]["fallacy_type"] == "ad populum"
+    result = classifier.classify_spans([RawSpan(text="x", start=0, end=1)])
+    assert result[0].status == "confirmed"
+    assert result[0].fallacy_type == "ad populum"
 
     # Below threshold
     fake_index2 = types.SimpleNamespace(
         search=lambda emb, k: (np.array([[0.75]], dtype="float32"), np.array([[0]]))
     )
     monkeypatch.setattr(classifier, "_load_resources", lambda: (fake_model, fake_index2, fake_labels))
-    result2 = classifier.classify_spans([{"text": "x", "start": 0, "end": 1}])
-    assert result2[0]["status"] == "possibly"
+    result2 = classifier.classify_spans([RawSpan(text="x", start=0, end=1)])
+    assert result2[0].status == "possibly"
 
 
 # Helper for sidecar tests: stub out the heavy SentenceTransformer/faiss loads

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -1,12 +1,13 @@
 from unittest.mock import MagicMock
 
+from models.span import ClassifiedSpan
 from pipeline.explainer import _SYSTEM_PROMPT, _fallback_content, generate_content
 
-SPANS = [{
-    "id": "a", "text": "Everyone knows politicians lie",
-    "start": 0, "end": 30, "status": "possibly",
-    "fallacy_type": "Ad Populum", "confidence": 0.71,
-}]
+SPANS = [ClassifiedSpan(
+    id="a", text="Everyone knows politicians lie",
+    start=0, end=30, status="possibly",
+    fallacy_type="Ad Populum", confidence=0.71,
+)]
 
 def _mock_parsed():
     from models.span import ExplainerChallenge, ExplainerOutput, ExplainerQuestion, ExplainerSpan
@@ -73,11 +74,11 @@ def test_falls_back_when_payload_exceeds_limit(monkeypatch):
     from pipeline.explainer import generate_content as reloaded_generate_content
 
     big_text = "x" * 500
-    big_spans = [{
-        "id": "a", "text": big_text,
-        "start": 0, "end": 500, "status": "possibly",
-        "fallacy_type": "Ad Populum", "confidence": 0.71,
-    }]
+    big_spans = [ClassifiedSpan(
+        id="a", text=big_text,
+        start=0, end=500, status="possibly",
+        fallacy_type="Ad Populum", confidence=0.71,
+    )]
     mock_client = MagicMock()
     result = reloaded_generate_content(big_spans, big_text, client=mock_client)
     assert result.spans[0].id == "a"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -6,8 +6,10 @@ from models.span import (
     AnalyzeResponse,
     Challenge,
     ChallengeType,
+    ClassifiedSpan,
     DependencyRule,
     Question,
+    RawSpan,
     SpanResult,
 )
 
@@ -54,4 +56,24 @@ def test_dependency_rule_rejects_lowercase_when():
             when="confirmed",
             effect="moot",
             reason="x",
+        )
+
+def test_raw_and_classified_span_construct_and_serialize():
+    raw = RawSpan(text="All scientists lie.", start=0, end=18)
+    classified = ClassifiedSpan(
+        **raw.model_dump(),
+        fallacy_type="Faulty Generalization",
+        confidence=0.91,
+        status="confirmed",
+    )
+    assert classified.id is None
+    data = classified.model_dump()
+    assert data["text"] == "All scientists lie."
+    assert data["fallacy_type"] == "Faulty Generalization"
+    assert data["status"] == "confirmed"
+
+    # `status` is a Literal — anything else must be rejected at construction.
+    with pytest.raises(ValidationError):
+        ClassifiedSpan(
+            text="x", start=0, end=1, fallacy_type="t", confidence=0.5, status="maybe",
         )

--- a/backend/tests/test_segmenter.py
+++ b/backend/tests/test_segmenter.py
@@ -39,21 +39,27 @@ NON_ARG = "The weather in Paris is often mild in spring."
 
 @pytest.mark.slow
 def test_returns_segmentation_result():
+    from models.span import RawSpan
+
     result = get_argument_spans(ARGUMENTATIVE)
     assert isinstance(result, SegmentationResult)
     assert isinstance(result.spans, list)
+    assert all(isinstance(s, RawSpan) for s in result.spans)
     assert isinstance(result.sentence_count, int)
 
 @pytest.mark.slow
 def test_argumentative_sentence_included():
     result = get_argument_spans(ARGUMENTATIVE)
-    assert any(ARGUMENTATIVE[:20] in s["text"] for s in result.spans)
+    assert any(ARGUMENTATIVE[:20] in s.text for s in result.spans)
 
 @pytest.mark.slow
-def test_span_has_required_keys():
+def test_span_has_required_fields():
     result = get_argument_spans(ARGUMENTATIVE)
     assert len(result.spans) > 0
-    assert {"text", "start", "end"} <= result.spans[0].keys()
+    span = result.spans[0]
+    assert isinstance(span.text, str)
+    assert isinstance(span.start, int)
+    assert isinstance(span.end, int)
 
 @pytest.mark.slow
 def test_empty_text_returns_empty():


### PR DESCRIPTION
## Diagrams

Class hierarchy of the new internal pipeline models (these are NOT on the wire — `SpanResult` remains the public response shape):

```mermaid
classDiagram
    class RawSpan {
        +text: str
        +start: int
        +end: int
    }
    class ClassifiedSpan {
        +id: str | None
        +fallacy_type: str
        +confidence: float
        +status: Literal["confirmed","possibly"]
    }
    RawSpan <|-- ClassifiedSpan
```

Type-flow change through the pipeline (before vs after):

```mermaid
flowchart LR
    subgraph Before
        Sb[segmenter] -- list[dict] --> Cb[classifier]
        Cb -- list[dict] --> Eb[explainer + main.py]
        Eb -- "span['text']" --> SRb[SpanResult]
    end
    subgraph After
        Sa[segmenter] -- list[RawSpan] --> Ca[classifier]
        Ca -- list[ClassifiedSpan] --> Ea[explainer + main.py]
        Ea -- "span.text" --> SRa[SpanResult]
    end
```

## Summary

- Type-safety: pyright now catches typos in field names and shape drift between producers and consumers; the previous `dict` boundary erased every key-name and value-type contract between segmenter, classifier, explainer, and `main.py`.

## Screenshots

N/A — not UI.

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — 51 passed (50 pre-existing + 1 new RawSpan/ClassifiedSpan test), 0 failures
- [x] `cd backend && ruff check .` — clean
- [x] `cd backend && pyright` — 0 errors, 5 warnings (all pre-existing: 3 missing third-party stubs for `faiss`/`datasets`, 2 private-usage on `_load_resources`/`_fallback_content` — unchanged from `main`)
- [x] No new `# pyright: ignore` suppressions introduced
- [x] Wire response shape unchanged (verified via `tests/test_api.py` — same JSON payload, same `SpanResult` fields)
- [x] `CONFIDENCE_THRESHOLD` still `0.82` in `pipeline/classifier.py`
- [x] Fallback path (`_fallback_content`) produces same `ExplainerOutput`
- [ ] `cd frontend && npm test` — N/A (backend-only)
- [ ] `cd frontend && npx tsc --noEmit` — N/A (backend-only)

## Plan reference

Closes #59. PR 7 of the 8-PR backend hardening effort.
