### PR TITLE
chore: address polish suggestions from PRs #62, #64, #65, #66, #67

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from models.span import (
     Challenge,
     ChallengeType,
     DependencyRule,
+    IdentifiedClassifiedSpan,
     Question,
     SpanResult,
 )
@@ -72,8 +73,13 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
 
     seg = get_argument_spans(text)
     raw_spans = seg.spans
-    classified = [
-        span.model_copy(update={"id": f"span_{i}"})
+    # Stamp an id on each ClassifiedSpan and lift to IdentifiedClassifiedSpan
+    # so downstream consumers (explainer, _fallback_content) get a static
+    # guarantee that .id is non-None — no runtime assert needed.
+    classified: list[IdentifiedClassifiedSpan] = [
+        IdentifiedClassifiedSpan.model_validate(
+            {**span.model_dump(), "id": f"span_{i}"}
+        )
         for i, span in enumerate(classify_spans(raw_spans))
     ]
 
@@ -82,9 +88,6 @@ def _analyze_sync(req: AnalyzeRequest) -> AnalyzeResponse:
 
     spans_out: list[SpanResult] = []
     for span in classified:
-        # main.py stamps an id onto every classified span above; assert as a
-        # precondition so a future change that drops the stamp loop fails loud.
-        assert span.id is not None
         sid = span.id
         c = content_by_id.get(sid)
         model_generated = c is not None

--- a/backend/models/span.py
+++ b/backend/models/span.py
@@ -31,6 +31,26 @@ class ClassifiedSpan(RawSpan):
     confidence: float
     status: Literal["confirmed", "possibly"]
 
+
+class IdentifiedClassifiedSpan(RawSpan):
+    """A ClassifiedSpan that has been stamped with an `id` by main.py.
+
+    Mirrors ClassifiedSpan's fields but with `id: str` required, so pyright
+    can statically catch callers that try to pass an unstamped span into the
+    post-stamp pipeline (the explainer + fallback path) — replacing a runtime
+    `assert span.id is not None` with a static guarantee.
+
+    Defined as a sibling of ClassifiedSpan rather than a subclass because
+    pyright treats Pydantic field overrides as mutable-and-invariant: a
+    `str | None = None` parent field cannot be narrowed to `str` in a child
+    without raising reportIncompatibleVariableOverride. Sibling models avoid
+    that constraint.
+    """
+    id: str
+    fallacy_type: str
+    confidence: float
+    status: Literal["confirmed", "possibly"]
+
 class Question(BaseModel):
     text: str
     yes_label: str

--- a/backend/pipeline/classifier.py
+++ b/backend/pipeline/classifier.py
@@ -28,12 +28,18 @@ MPNET_REVISION = "e8c3b32edf5434bc2275fc9bab85f82640a19130"
 logger = logging.getLogger(__name__)
 
 
-def _verify_index_metadata() -> None:
-    # Sidecar is written by data/build_index.py. Asserting embedder_model
-    # match catches the silent failure mode where the index was built with a
-    # different sentence-transformer than the loader is about to instantiate
-    # — dimensions would still match, FAISS would return nearest neighbors,
-    # and classifications would quietly degrade with no error.
+def _verify_index_metadata(index: faiss.Index) -> None:
+    # Sidecar is written by data/build_index.py. Each check catches a different
+    # silent-degradation failure mode:
+    # - embedder_model: different sentence-transformer family with the same
+    #   dimension would still produce nearest neighbors with no error.
+    # - embedder_revision: same family but a different upstream commit; weights
+    #   shift, query embeddings drift apart from indexed ones. Only enforced
+    #   when the sidecar declares one (older sidecars predate the field).
+    # - embedding_dim: must match the FAISS index dimension or .search() fails
+    #   with a cryptic shape error, not a clear classifier-config diagnostic.
+    # - vector_count: rebuilt-but-not-shipped index is the most common dev
+    #   gotcha; sidecar may be ahead of the .index file (or vice versa).
     meta_path = DATA_DIR / "logical_fallacy.index.meta.json"
     if not meta_path.exists():
         warnings.warn(
@@ -44,6 +50,7 @@ def _verify_index_metadata() -> None:
         )
         return
     meta = json.loads(meta_path.read_text())
+
     indexed_embedder = meta.get("embedder_model")
     if indexed_embedder != EMBEDDER_MODEL:
         raise RuntimeError(
@@ -52,14 +59,38 @@ def _verify_index_metadata() -> None:
             f"python data/build_index.py"
         )
 
+    indexed_revision = meta.get("embedder_revision")
+    if indexed_revision is not None and indexed_revision != MPNET_REVISION:
+        raise RuntimeError(
+            f"FAISS index was built with embedder revision "
+            f"{indexed_revision!r} but classifier pins {MPNET_REVISION!r}. "
+            f"Rebuild the index: python data/build_index.py"
+        )
+
+    indexed_dim = meta.get("embedding_dim")
+    if indexed_dim is not None and indexed_dim != index.d:
+        raise RuntimeError(
+            f"FAISS index sidecar declares embedding_dim={indexed_dim} but "
+            f"the loaded index reports dim={index.d}. Rebuild the index: "
+            f"python data/build_index.py"
+        )
+
+    indexed_count = meta.get("vector_count")
+    if indexed_count is not None and indexed_count != index.ntotal:
+        raise RuntimeError(
+            f"FAISS index sidecar declares vector_count={indexed_count} but "
+            f"the loaded index reports ntotal={index.ntotal}. Rebuild the "
+            f"index: python data/build_index.py"
+        )
+
 
 @lru_cache(maxsize=1)
 def _load_resources():
-    _verify_index_metadata()
     device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("sentence-transformers device: %s", device)
     model = SentenceTransformer(EMBEDDER_MODEL, device=device, revision=MPNET_REVISION)
     index = faiss.read_index(str(DATA_DIR / "logical_fallacy.index"))
+    _verify_index_metadata(index)
     labels = json.loads((DATA_DIR / "logical_fallacy_labels.json").read_text())
     return model, index, labels
 

--- a/backend/pipeline/explainer.py
+++ b/backend/pipeline/explainer.py
@@ -6,11 +6,11 @@ from typing import Literal, cast
 from openai import OpenAI
 
 from models.span import (
-    ClassifiedSpan,
     ExplainerChallenge,
     ExplainerOutput,
     ExplainerQuestion,
     ExplainerSpan,
+    IdentifiedClassifiedSpan,
 )
 from pipeline.challenge_types import challenge_type_for
 
@@ -67,17 +67,13 @@ _TEMPLATE_QUESTIONS = {
                              "Well established → not a fallacy"),
 }
 
-def _fallback_content(spans: list[ClassifiedSpan]) -> ExplainerOutput:
+def _fallback_content(spans: list[IdentifiedClassifiedSpan]) -> ExplainerOutput:
     result_spans = []
     for span in spans:
         # challenge_type_for returns one of the keys of _TEMPLATE_QUESTIONS,
         # which is exactly ChallengeTypeLiteral; cast to the narrower type.
         ct = cast(ChallengeTypeLiteral, challenge_type_for(span.fallacy_type))
         q_text, yes_lbl, no_lbl = _TEMPLATE_QUESTIONS[ct]
-        # main.py stamps an id onto every span before this is reached; assert
-        # it as a precondition so a bug upstream surfaces here, not as a silent
-        # `id=None` propagating into the wire response.
-        assert span.id is not None, "span.id must be set before _fallback_content"
         result_spans.append(ExplainerSpan(
             id=span.id,
             explanation=f"Possibly a {span.fallacy_type}.",
@@ -91,7 +87,7 @@ def _fallback_content(spans: list[ClassifiedSpan]) -> ExplainerOutput:
     return ExplainerOutput(spans=result_spans, dependency_rules=[])
 
 def generate_content(
-    spans: list[ClassifiedSpan],
+    spans: list[IdentifiedClassifiedSpan],
     full_text: str,
     client: OpenAI | None = None,
 ) -> ExplainerOutput:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -26,9 +26,12 @@ FALLACY_LABELS: list[str] = sorted(set(json.loads(
 def _reset_rate_limiter():
     # slowapi's in-memory storage persists across tests within a process and
     # all tests use the same default client IP (127.0.0.1). Reset the limiter
-    # state before every test so they don't poison each other.
+    # state before every test so they don't poison each other. Use the public
+    # Limiter.reset() rather than reaching into ._storage.storage — the
+    # in-memory backend also tracks expirations/events/locks beside the
+    # counter dict, and a moving-window strategy uses different state
+    # entirely. Limiter.reset() delegates to the storage's own reset(), which
+    # clears all of those in one shot.
     from main import app
-    storage = app.state.limiter._storage
-    if hasattr(storage, "storage"):
-        storage.storage.clear()
+    app.state.limiter.reset()
     yield

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -56,12 +56,13 @@ def test_threshold_determines_status(monkeypatch):
 
 # Helper for sidecar tests: stub out the heavy SentenceTransformer/faiss loads
 # so we exercise only the metadata read+verify path. We seed _SENTINEL_SLOT with
-# a callable that returns a fake (model, index, labels) triple.
-def _stub_heavy_loads(monkeypatch, classifier_mod):
+# a callable that returns a fake (model, index, labels) triple. `d` and
+# `ntotal` mirror the FAISS Index attributes consulted by the verifier.
+def _stub_heavy_loads(monkeypatch, classifier_mod, *, dim: int = 768, ntotal: int = 1):
     import types
 
     fake_model = types.SimpleNamespace(encode=lambda *a, **k: None)
-    fake_index = types.SimpleNamespace(search=lambda *a, **k: None)
+    fake_index = types.SimpleNamespace(search=lambda *a, **k: None, d=dim, ntotal=ntotal)
     fake_labels = ["x"]
 
     def fake_st(*args, **kwargs):
@@ -102,6 +103,7 @@ def test_load_resources_raises_on_embedder_mismatch(monkeypatch, tmp_path):
     (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
         "embedder_model": "some-other-embedder",
         "embedder_library_version": "0.0.0",
+        "embedder_revision": classifier.MPNET_REVISION,
         "embedding_dim": 768,
         "vector_count": 1,
     }))
@@ -114,7 +116,32 @@ def test_load_resources_raises_on_embedder_mismatch(monkeypatch, tmp_path):
     classifier._load_resources.cache_clear()
 
 
-def test_load_resources_accepts_matching_sidecar(monkeypatch, tmp_path):
+def test_load_resources_raises_on_embedder_revision_mismatch(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": classifier.EMBEDDER_MODEL,
+        "embedder_library_version": "5.4.1",
+        "embedder_revision": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "embedding_dim": 768,
+        "vector_count": 1,
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier)
+
+    with pytest.raises(RuntimeError, match="revision"):
+        classifier._load_resources()
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_accepts_sidecar_without_revision(monkeypatch, tmp_path):
+    # Backward-compat: an older sidecar (pre-revision) should not block startup
+    # — only a sidecar that *declares* a revision must match.
     from pipeline import classifier
 
     classifier._load_resources.cache_clear()
@@ -131,6 +158,75 @@ def test_load_resources_accepts_matching_sidecar(monkeypatch, tmp_path):
     monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
     _stub_heavy_loads(monkeypatch, classifier)
 
-    model, index, labels = classifier._load_resources()
+    _model, _index, labels = classifier._load_resources()
+    assert labels == ["x"]
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_raises_on_embedding_dim_mismatch(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": classifier.EMBEDDER_MODEL,
+        "embedder_library_version": "5.4.1",
+        "embedder_revision": classifier.MPNET_REVISION,
+        "embedding_dim": 384,  # mismatch: stub reports d=768
+        "vector_count": 1,
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier, dim=768, ntotal=1)
+
+    with pytest.raises(RuntimeError, match="embedding_dim"):
+        classifier._load_resources()
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_raises_on_vector_count_mismatch(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": classifier.EMBEDDER_MODEL,
+        "embedder_library_version": "5.4.1",
+        "embedder_revision": classifier.MPNET_REVISION,
+        "embedding_dim": 768,
+        "vector_count": 999,  # mismatch: stub reports ntotal=1
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier, dim=768, ntotal=1)
+
+    with pytest.raises(RuntimeError, match="vector_count"):
+        classifier._load_resources()
+    classifier._load_resources.cache_clear()
+
+
+def test_load_resources_accepts_matching_sidecar(monkeypatch, tmp_path):
+    from pipeline import classifier
+
+    classifier._load_resources.cache_clear()
+
+    (tmp_path / "logical_fallacy.index").write_bytes(b"")
+    (tmp_path / "logical_fallacy_labels.json").write_text(json.dumps(["x"]))
+    (tmp_path / "logical_fallacy.index.meta.json").write_text(json.dumps({
+        "embedder_model": classifier.EMBEDDER_MODEL,
+        "embedder_library_version": "5.4.1",
+        "embedder_revision": classifier.MPNET_REVISION,
+        "embedding_dim": 768,
+        "vector_count": 1,
+    }))
+
+    monkeypatch.setattr(classifier, "DATA_DIR", tmp_path)
+    _stub_heavy_loads(monkeypatch, classifier, dim=768, ntotal=1)
+
+    _model, _index, labels = classifier._load_resources()
     assert labels == ["x"]
     classifier._load_resources.cache_clear()

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from models.span import ClassifiedSpan
+from models.span import IdentifiedClassifiedSpan
 from pipeline.explainer import _SYSTEM_PROMPT, _fallback_content, generate_content
 
-SPANS = [ClassifiedSpan(
+SPANS = [IdentifiedClassifiedSpan(
     id="a", text="Everyone knows politicians lie",
     start=0, end=30, status="possibly",
     fallacy_type="ad populum", confidence=0.71,
@@ -81,7 +81,7 @@ def test_falls_back_when_payload_exceeds_limit(monkeypatch):
         from pipeline.explainer import generate_content as reloaded_generate_content
 
         big_text = "x" * 500
-        big_spans = [ClassifiedSpan(
+        big_spans = [IdentifiedClassifiedSpan(
             id="a", text=big_text,
             start=0, end=500, status="possibly",
             fallacy_type="ad populum", confidence=0.71,
@@ -120,7 +120,7 @@ def test_generate_content_real_openai_round_trip():
 
     Run locally: OPENAI_API_KEY=sk-... pytest -v -m slow tests/test_explainer.py
     """
-    real_span = ClassifiedSpan(
+    real_span = IdentifiedClassifiedSpan(
         id="a", text="Everyone knows politicians always lie.",
         start=0, end=38, status="possibly",
         fallacy_type="ad populum", confidence=0.71,

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -69,28 +69,31 @@ def test_returns_empty_output_when_no_spans():
 
 def test_falls_back_when_payload_exceeds_limit(monkeypatch):
     monkeypatch.setenv("EXPLAINER_MAX_PAYLOAD_CHARS", "100")
-    # Re-import to pick up new env var since constants are module-level
+    # Re-import to pick up new env var since constants are module-level.
+    # try/finally so a failed assertion still restores the un-monkeypatched
+    # module — otherwise downstream tests inherit a polluted explainer with
+    # _MAX_PAYLOAD_CHARS=100.
     import importlib
 
     import pipeline.explainer
     importlib.reload(pipeline.explainer)
-    from pipeline.explainer import generate_content as reloaded_generate_content
+    try:
+        from pipeline.explainer import generate_content as reloaded_generate_content
 
-    big_text = "x" * 500
-    big_spans = [ClassifiedSpan(
-        id="a", text=big_text,
-        start=0, end=500, status="possibly",
-        fallacy_type="ad populum", confidence=0.71,
-    )]
-    mock_client = MagicMock()
-    result = reloaded_generate_content(big_spans, big_text, client=mock_client)
-    assert result.spans[0].id == "a"
-    assert result.spans[0].explanation != ""
-    mock_client.chat.completions.parse.assert_not_called()
-
-    # Reset for other tests
-    monkeypatch.delenv("EXPLAINER_MAX_PAYLOAD_CHARS", raising=False)
-    importlib.reload(pipeline.explainer)
+        big_text = "x" * 500
+        big_spans = [ClassifiedSpan(
+            id="a", text=big_text,
+            start=0, end=500, status="possibly",
+            fallacy_type="ad populum", confidence=0.71,
+        )]
+        mock_client = MagicMock()
+        result = reloaded_generate_content(big_spans, big_text, client=mock_client)
+        assert result.spans[0].id == "a"
+        assert result.spans[0].explanation != ""
+        mock_client.chat.completions.parse.assert_not_called()
+    finally:
+        monkeypatch.delenv("EXPLAINER_MAX_PAYLOAD_CHARS", raising=False)
+        importlib.reload(pipeline.explainer)
 
 def test_passes_max_completion_tokens():
     mock_client = MagicMock()

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -94,3 +94,27 @@ def test_identified_classified_span_requires_id():
         fallacy_type="t", confidence=0.5, status="possibly",
     )
     assert span.id == "span_0"
+
+
+def test_fixture_fallacy_types_are_canonical():
+    """Every fallacy_type used in test fixtures must appear in
+    logical_fallacy_labels.json.
+
+    conftest.FALLACY_LABELS exists to be the canonical source-of-truth for
+    test fixtures. Without an enforcement test, a typo like "ad-populum"
+    would only surface as a downstream silent mismatch. This test imports
+    the test-module fixture spans directly and asserts every fallacy_type
+    is in the canonical labels set.
+    """
+    from tests import test_api, test_explainer
+    from tests.conftest import FALLACY_LABELS
+
+    used = {s.fallacy_type for s in test_api.MOCK_CLASSIFIED}
+    used |= {s.fallacy_type for s in test_explainer.SPANS}
+
+    canonical = set(FALLACY_LABELS)
+    drift = used - canonical
+    assert not drift, (
+        f"test fixtures use fallacy_type(s) {drift!r} not in "
+        f"logical_fallacy_labels.json — fix the fixture or rebuild the index"
+    )

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -8,6 +8,7 @@ from models.span import (
     ChallengeType,
     ClassifiedSpan,
     DependencyRule,
+    IdentifiedClassifiedSpan,
     Question,
     RawSpan,
     SpanResult,
@@ -77,3 +78,19 @@ def test_raw_and_classified_span_construct_and_serialize():
         ClassifiedSpan(
             text="x", start=0, end=1, fallacy_type="t", confidence=0.5, status="maybe",
         )
+
+
+def test_identified_classified_span_requires_id():
+    # Subclass tightens id from `str | None = None` to `str` so the post-stamp
+    # pipeline (explainer + fallback) can rely on `.id` being non-None
+    # statically rather than via a runtime assert.
+    with pytest.raises(ValidationError):
+        IdentifiedClassifiedSpan(
+            text="x", start=0, end=1, fallacy_type="t", confidence=0.5, status="possibly",
+        )
+
+    span = IdentifiedClassifiedSpan(
+        id="span_0", text="x", start=0, end=1,
+        fallacy_type="t", confidence=0.5, status="possibly",
+    )
+    assert span.id == "span_0"


### PR DESCRIPTION
## Diagrams

```mermaid
classDiagram
    class RawSpan {
        +text: str
        +start: int
        +end: int
    }
    class ClassifiedSpan {
        +id: str | None = None
        +fallacy_type: str
        +confidence: float
        +status: Literal
    }
    class IdentifiedClassifiedSpan {
        +id: str  «required»
        +fallacy_type: str
        +confidence: float
        +status: Literal
    }
    RawSpan <|-- ClassifiedSpan : classifier output
    RawSpan <|-- IdentifiedClassifiedSpan : after id stamp

    note for ClassifiedSpan "boundary type:\nclassifier emits, main.py consumes"
    note for IdentifiedClassifiedSpan "boundary type:\nexplainer + _fallback_content require"
```

```mermaid
sequenceDiagram
    participant Main as main._analyze_sync
    participant Cls as classifier
    participant Exp as explainer

    Cls-->>Main: list[ClassifiedSpan]  (id may be None)
    Main->>Main: stamp id, model_validate -> IdentifiedClassifiedSpan
    Main->>Exp: generate_content(list[IdentifiedClassifiedSpan], text)
    Note over Exp: signature now requires the post-stamp type<br/>— pyright catches any caller that skips the stamp
    Exp-->>Main: ExplainerOutput
```

## Summary

- Five small follow-ups bundled from julianken-bot reviews on PRs #62, #64, #65, #66, #67. Each is unrelated to the others; each was the bot's stated remaining concern after merging the parent PR.
- Together these tighten test isolation (#62, #64), broaden silent-degradation detection in the FAISS sidecar verifier (#65), replace a runtime `assert` with a static type guarantee (#66), and turn a documented-but-unenforced fixture contract into an actual test (#67).
- No behavior changes for end users — every change is an internal correctness/observability improvement.

## Polish suggestions addressed

### #62 — `backend/tests/conftest.py:24`

Origin: [pull/62#discussion_r3106335543](https://github.com/julianken/fallacy-watch/pull/62#discussion_r3106335543) (review [#4135522143](https://github.com/julianken/fallacy-watch/pull/62#pullrequestreview-4135522143))

> `app.state.limiter._storage.storage.clear()` reaches private slowapi internals. The class also tracks `expirations`, `events`, and `locks` (`limits/storage/memory.py`); use the public `Limiter.reset()` instead. Quietly broken if anyone switches from `fixed-window` to `moving-window` strategy.

Fix: replaced the autouse fixture body with `app.state.limiter.reset()`. `Limiter.reset()` delegates to the storage's own `reset()`, which clears all internal structures atomically across strategies. See `922ec2e`.

### #64 — `backend/tests/test_explainer.py:89`

Origin: [pull/64#discussion_r3106754113](https://github.com/julianken/fallacy-watch/pull/64#discussion_r3106754113) (review [#4135884734](https://github.com/julianken/fallacy-watch/pull/64#pullrequestreview-4135884734))

> Test cleanup (`monkeypatch.delenv` + `importlib.reload`) is order-dependent. If assertions raise, cleanup doesn't run, leaving the reloaded `pipeline.explainer` module in a polluted state for downstream tests.

Fix: wrapped the assertions in `try`, moved the env restore + reload into the `finally` block. A failing assertion now still restores the unmonkeypatched module. See `272a4fe`.

### #65 — `backend/pipeline/classifier.py:46`

Origin: [pull/65#discussion_r3106778415](https://github.com/julianken/fallacy-watch/pull/65#discussion_r3106778415) (review [#4135904478](https://github.com/julianken/fallacy-watch/pull/65#pullrequestreview-4135904478))

> Sidecar stamps `embedder_revision`, `embedding_dim`, and `vector_count` (`build_index.py:61-63`), but `_verify_index_metadata()` only checks `embedder_model`. Catches embedder-family swap but not revision-drift (the case the PR comment at line 17 explicitly cites).

Fix: extended `_verify_index_metadata()` to also raise on revision/dim/count mismatch — each gated on the sidecar field being present so older sidecars still load. Verification now runs after the FAISS index is loaded so dim/count comparison can read `index.d`/`index.ntotal`. Three new test cases (`test_load_resources_raises_on_embedder_revision_mismatch`, `_dim_mismatch`, `_vector_count_mismatch`) plus a backward-compat regression (`test_load_resources_accepts_sidecar_without_revision`). See `86ca028`.

### #66 — `backend/models/span.py:26`

Origin: [pull/66#discussion_r3106799083](https://github.com/julianken/fallacy-watch/pull/66#discussion_r3106799083) (review [#4135919986](https://github.com/julianken/fallacy-watch/pull/66#pullrequestreview-4135919986))

> `ClassifiedSpan.id: str | None = None` + `assert span.id is not None` pattern in `_fallback_content` (explainer.py:80) and main.py:87 expresses post-stamp precondition at runtime. Pydantic could express it statically.

Fix: added `IdentifiedClassifiedSpan` (sibling model with `id: str` required), have `main.py` lift each `ClassifiedSpan` to it via `model_validate` after stamping. `_fallback_content` and `generate_content` now take `list[IdentifiedClassifiedSpan]`; both runtime asserts dropped. Sibling rather than subclass because pyright treats Pydantic field overrides as mutable-and-invariant — narrowing `str | None = None` to `str` in a subclass would have raised `reportIncompatibleVariableOverride` and required a suppression. Verified pyright now catches `list[ClassifiedSpan]` passed to `_fallback_content` as a type error. See `aaeb090`.

### #67 — `backend/tests/conftest.py:22`

Origin: [pull/67#discussion_r3106829646](https://github.com/julianken/fallacy-watch/pull/67#discussion_r3106829646) (review [#4135947001](https://github.com/julianken/fallacy-watch/pull/67#pullrequestreview-4135947001))

> `FALLACY_LABELS` constant is defined but never imported. Doesn't enforce anything.

Decision: **added a guard test** rather than deleting the constant. `FALLACY_LABELS`'s docstring already promised this contract — the test now backs it. `test_fixture_fallacy_types_are_canonical` imports `MOCK_CLASSIFIED` from `test_api` and `SPANS` from `test_explainer`, asserts every fallacy_type appears in `FALLACY_LABELS`, and was sanity-checked by injecting `fallacy_type = "NotARealFallacy"` and confirming it raises `AssertionError`. See `56e44be`.

## Screenshots

N/A — not UI

## Test plan

- [x] `cd backend && source .venv/bin/activate && pytest -v -m "not slow"` — green (61 passed, 8 deselected)
- [x] `cd backend && pyright` — 0 errors (5 pre-existing warnings about missing third-party stubs)
- [x] `cd backend && ruff check .` — green
- [x] New tests added for items #65 (4 cases) and #67 (1 case); item #66 added `test_identified_classified_span_requires_id` to `test_models.py`
- [x] No new pyright suppressions
- [x] No types loosened — item #66 *tightens* by removing the `assert span.id is not None` runtime check via static typing

## Plan reference

Follow-up to PRs #62, #64, #65, #66, #67. Not closing any issue — these are bot-suggestion follow-ups bundled into one PR for clean review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
